### PR TITLE
fix: Fix to send data in string_data in case the content-type is text/plain or x-wwww-form-urlencoded

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -208,12 +208,8 @@ func (p *Proxy) processAttempt(msg websocket.IncomingMessage) {
 		client := &http.Client{
 			Timeout: time.Duration(timeout) * time.Millisecond,
 		}
-		// body := webhookEvent.Body.Request.Headers
-		// h := make(map[string]json.RawMessage)
-		// json.Unmarshal(webhookEvent.Body.Request.Headers, &h);
 		fmt.Println(bytes.NewBuffer(webhookEvent.Body.Request.Headers));
 
-		// req, err := http.NewRequest(webhookEvent.Body.Request.Method, url, bytes.NewBuffer(webhookEvent.Body.Request.Data))
 		req, err := http.NewRequest(webhookEvent.Body.Request.Method, url, nil)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)

--- a/pkg/websocket/attempt_messages.go
+++ b/pkg/websocket/attempt_messages.go
@@ -5,10 +5,11 @@ import (
 )
 
 type AttemptRequest struct {
-	Method  string          `json:"method"`
-	Timeout int64           `json:"timeout"`
-	Data    json.RawMessage `json:"data"`
-	Headers json.RawMessage `json:"headers"`
+	Method  		string          `json:"method"`
+	Timeout 		int64           `json:"timeout"`
+	Data    		json.RawMessage `json:"data"`
+	DataString	string      		`json:"data_string"`
+	Headers 		json.RawMessage `json:"headers"`
 }
 
 type AttemptBody struct {


### PR DESCRIPTION
…text/plain or x-wwww-form-urlencoded

data_string is what is sent as a POST payload to the listening server in case the content-type is one that indicates that the body is a string.