### PR TITLE
Refactor connection logic

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -151,7 +151,8 @@ func (p *Proxy) Run(parentCtx context.Context) error {
 			return nil
 		case <-p.webSocketClient.NotifyExpired:
 			if canConnect() {
-				ansi.StartSpinner(s, "Connection lost, reconnecting...", p.cfg.Log.Out)
+				ansi.StopSpinner(s, "", p.cfg.Log.Out)
+				s = ansi.StartNewSpinner("Connection lost, reconnecting...", p.cfg.Log.Out)
 			} else {
 				p.cfg.Log.Fatalf("Session expired. Terminating after %d failed attempts to reauthorize", nAttempts)
 			}

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -125,7 +125,7 @@ func (c *Client) Run(ctx context.Context) {
 				"prefix": "websocket.client.Run",
 			}).Debug("Websocket session is expired.")
 		}
-		c.Restart()
+		c.ConnectionLost()
 		return
 	}
 
@@ -147,16 +147,16 @@ func (c *Client) Run(ctx context.Context) {
 		c.cfg.Log.WithFields(log.Fields{
 			"prefix": "websocket.client.Run",
 		}).Debug("Disconnected from Hookdeck")
-		c.NotifyExpired <- struct{}{}
+
+		c.ConnectionLost()
 		close(c.stopReadPump)
 		close(c.stopWritePump)
 		c.wg.Wait()
 	}
 }
 
-// Restart stops the client and notifies the context.
-func (c *Client) Restart() {
-	c.Stop()
+// ConnectionLost sends NotifyExpired
+func (c *Client) ConnectionLost() {
 	c.NotifyExpired <- struct{}{}
 }
 


### PR DESCRIPTION
This PR addresses the CLI synchronization issues by making several changes:

- `websocket.Client.Run` no longer retries connections
  - If a connection is not established the new `Client.ConnectionLost` method is called to notify the expiration channel 
- `websocket.Client.Config` no longer supports `ReconnectInterval`
- `proxy.Proxy.Run` now supports retrying connections indefinitely
  - Indefinite retries are subject to exponential backoff up to 10 seconds

Additionally I have:

- Updated the spinner to explicitly stop and start a new instance on reconnect to fix an intermittent display bug
- Refactored `proxy.Proxy.createSession`
  - Removed unnecessary goroutine
  - Always return as errors are checked
- Added additional comments

Closes #23 