### PR TITLE
chore: Add Linux ARM build

### DIFF
--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -17,6 +17,17 @@ builds:
       - linux
     goarch:
       - amd64
+  - id: hookdeck-linux-arm
+    ldflags:
+      - -s -w -X github.com/hookdeck/hookdeck-cli/pkg/version.Version={{.Version}}
+    binary: hookdeck
+    env:
+      - CGO_ENABLED=0
+    main: ./main.go
+    goos:
+      - linux
+    goarch:
+      - arm
 archives:
   - replacements:
       linux: linux


### PR DESCRIPTION
This PR adds a goreleaser stanza to build the CLI for Linux on ARM.