### PR TITLE
Added support for self signed/insecure SSL certs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ Logout of your Hookdeck account and clear your stored credentials.
 hookdeck logout
 ```
 
+### Skip SSL validation
+
+If you are developing on an SSL destination, and are using a self-signed certificate, you can skip the SSL validation by using the flag `--insecure`.
+You have to specify the full URL with the protocol when using this flag.
+
+**This is dangerous, and should only be used in development scenarios, and for desitnations that you trust.**
+
+```sh-session
+hookdeck --insecure listen https://<url-or-url:port>/
+```
+
 ### Version
 
 Print your CLI version and whether or not a new version is available.

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -94,6 +94,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&Config.ProfilesFile, "config", "", "config file (default is $HOME/.config/hookdeck/config.toml)")
 	rootCmd.PersistentFlags().StringVar(&Config.Profile.DeviceName, "device-name", "", "device name")
 	rootCmd.PersistentFlags().StringVar(&Config.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")
+	rootCmd.PersistentFlags().BoolVar(&Config.Insecure, "insecure", false, "Allow invalid TLS certificates")
 	rootCmd.PersistentFlags().StringVarP(&Config.Profile.ProfileName, "project-name", "p", "default", "the project name to read from for config")
 
 	// Hidden configuration flags, useful for dev/debugging

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	ProfilesFile     string
 	APIBaseURL       string
 	DashboardBaseURL string
+	Insecure         bool
 }
 
 // GetConfigFolder retrieves the folder where the profiles file is stored

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -114,6 +114,7 @@ func Listen(URL *url.URL, source_alias string, connection_query string, flags Fl
 		NoWSS:            flags.NoWSS,
 		URL:              URL,
 		Log:              log.StandardLogger(),
+		Insecure:         config.Insecure,
 	}, source, connections)
 
 	err = p.Run(context.Background())


### PR DESCRIPTION
Introduce a new `--insecure` flag to allow to connect to destinations with self signed certs. 
This is dangerous, and should only be used for development with self signed SSL certificates and similar scenarios.