### PR TITLE
feat: Read config from local workspace config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage.txt
 /hookdeck-linux
 /hookdeck-windows.exe
 /hookdeck-cli
+/hookdeck.toml
 default_cassette.yaml
 .vscode/
 __debug_bin

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hookdeck/hookdeck-cli/pkg/hookdeck"
 	"github.com/hookdeck/hookdeck-cli/pkg/listen"
 	"github.com/spf13/cobra"
 )
@@ -75,7 +74,6 @@ func newListenCmd() *listenCmd {
 		},
 		RunE: lc.runListenCmd,
 	}
-	lc.cmd.Flags().StringVar(&lc.wsBaseURL, "ws-base", hookdeck.DefaultWebsocektURL, "Sets the Websocket base URL")
 	lc.cmd.Flags().BoolVar(&lc.noWSS, "no-wss", false, "Force unencrypted ws:// protocol instead of wss://")
 
 	return lc
@@ -108,7 +106,6 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	return listen.Listen(url, source_alias, connection_query, listen.Flags{
-		WSBaseURL: lc.wsBaseURL,
 		NoWSS:     lc.noWSS,
 	}, &Config)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -95,12 +95,13 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&Config.Profile.DeviceName, "device-name", "", "device name")
 	rootCmd.PersistentFlags().StringVar(&Config.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().BoolVar(&Config.Insecure, "insecure", false, "Allow invalid TLS certificates")
-	rootCmd.PersistentFlags().StringVarP(&Config.Profile.ProfileName, "project-name", "p", "default", "the project name to read from for config")
+	rootCmd.PersistentFlags().StringVarP(&Config.Profile.ProfileName, "project-name", "p", "", fmt.Sprintf("the project name to read from for config (default \"%s\")", hookdeck.DefaultProfileName))
 
 	// Hidden configuration flags, useful for dev/debugging
-	rootCmd.PersistentFlags().StringVar(&Config.APIBaseURL, "api-base", hookdeck.DefaultAPIBaseURL, "Sets the API base URL")
-	rootCmd.PersistentFlags().StringVar(&Config.DashboardBaseURL, "dashboard-base", hookdeck.DefaultDashboardBaseURL, "Sets the web dashboard base URL")
-	rootCmd.PersistentFlags().StringVar(&Config.ConsoleBaseURL, "console-base", hookdeck.DefaultConsoleBaseURL, "Sets the web console base URL")
+	rootCmd.PersistentFlags().StringVar(&Config.APIBaseURL, "api-base", "", fmt.Sprintf("Sets the API base URL (default \"%s\")", hookdeck.DefaultAPIBaseURL))
+	rootCmd.PersistentFlags().StringVar(&Config.DashboardBaseURL, "dashboard-base", "", fmt.Sprintf("Sets the web dashboard base URL (default \"%s\")", hookdeck.DefaultDashboardBaseURL))
+	rootCmd.PersistentFlags().StringVar(&Config.ConsoleBaseURL, "console-base", "", fmt.Sprintf("Sets the web console base URL (default \"%s\")", hookdeck.DefaultConsoleBaseURL))
+	rootCmd.PersistentFlags().StringVar(&Config.WSBaseURL, "ws-base", "", fmt.Sprintf("Sets the Websocket base URL (default \"%s\")", hookdeck.DefaultWebsocektURL))
 
 	rootCmd.Flags().BoolP("version", "v", false, "Get the version of the Hookdeck CLI")
 

--- a/pkg/hookdeck/client.go
+++ b/pkg/hookdeck/client.go
@@ -28,6 +28,8 @@ const DefaultConsoleBaseURL = "http://console.hookdeck.com"
 
 const DefaultWebsocektURL = "wss://ws.hookdeck.com"
 
+const DefaultProfileName = "default"
+
 // Client is the API client used to sent requests to Hookdeck.
 type Client struct {
 	// The base URL (protocol + hostname) used for all requests sent by this

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -32,7 +32,6 @@ import (
 
 type Flags struct {
 	NoWSS     bool
-	WSBaseURL string
 }
 
 // listenCmd represents the listen command
@@ -119,7 +118,7 @@ func Listen(URL *url.URL, source_alias string, connection_query string, flags Fl
 		DashboardBaseURL: config.DashboardBaseURL,
 		ConsoleBaseURL:   config.ConsoleBaseURL,
 		Profile:          config.Profile,
-		WSBaseURL:        flags.WSBaseURL,
+		WSBaseURL:        config.WSBaseURL,
 		NoWSS:            flags.NoWSS,
 		URL:              URL,
 		Log:              log.StandardLogger(),


### PR DESCRIPTION
This PR allows users to provide a local `hookdeck.toml` within their workspace. The order that we're reading the config is:

1. flags (`hookdeck whoami -p alex`)
2. local directory config (or if you pass -c file then that's the local config)
3. global config `~/.config/hookdeck/config.toml`
4. default values

---

# ARCHIVED - not relevant anymore

This PR does 2 main things:

1. read `hookdeck.toml` locally wherever you're running the CLI for global flags (color, profile, base api, etc)

The order that we're reading the config is:

1. flags (`hookdeck whoami -p alex`)
2. local directory config (or if you pass -c file then that's the local config)
3. global config `~/.config/hookdeck/config.toml`
4. default values

---

2. manage a local "workspace" or "profile"

New commands:

```
$ hookdeck workspace list

# equivalent: $ hookdeck login -p alex
$ hookdeck workspace login alex

$ hookdeck workspace use alex
```

I think there is still a bit DX to figure out around this. One question I have is whether `$ hookdeck workspace use alex` should persist locally or globally. Current behavior is locally, so it will modify (or create) a local hookdeck.toml file, which may or may not be the desired behavior.

After doing a bit of research at what other CLIs do, I've found some introduce either a command or flag "global / local" to specify that.

Example:

```
$ hookdeck workspace use alex --global
$ hookdeck workspace use alex --local

# OR

$ hookdeck workspace local alex
$ hookdeck workspace global alex

# OR

$ hookdeck global workspace alex
$ hookdeck local workspace alex
```

Curious to hear what you think makes sense!