### PR TITLE
fix: Check if connection has a name before comparing with connection query

### DIFF
--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -38,7 +38,7 @@ func getConnections(client *hookdeckclient.Client, source *hookdecksdk.Source, c
 		}
 		var filteredConnections []*hookdecksdk.Connection
 		for _, connection := range connections {
-			if (is_path && connection.Destination.CliPath != nil && strings.Contains(*connection.Destination.CliPath, connectionQuery)) || *connection.Name == connectionQuery {
+			if (is_path && connection.Destination.CliPath != nil && strings.Contains(*connection.Destination.CliPath, connectionQuery)) || (connection.Name != nil && *connection.Name == connectionQuery) {
 				filteredConnections = append(filteredConnections, connection)
 			}
 		}


### PR DESCRIPTION
When we run `hookdeck listen 1234 source-name connection-name`, if the source has a connection without a name, it may run into nil pointer issue. This PR will check to make sure the pointer exists first before dereference it.