### PR TITLE
v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hookdeck/hookdeck-go-sdk v0.0.37 // indirect
+	github.com/hookdeck/hookdeck-go-sdk v0.4.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/pty v1.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDG
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hookdeck/hookdeck-go-sdk v0.0.37 h1:Y+QnwsWuJ6KMkpY2qJZDeGzcKc4GkzBrRaEnIb8zimc=
 github.com/hookdeck/hookdeck-go-sdk v0.0.37/go.mod h1:kfFn3/WEGcxuPkaaf8lAq9L+3nYg45GwGy4utH/Tnmg=
+github.com/hookdeck/hookdeck-go-sdk v0.4.1 h1:r/rZJeBuDq31amTIB1LDHkA5lTAG2jAmZGqhgHRYKy8=
+github.com/hookdeck/hookdeck-go-sdk v0.4.1/go.mod h1:kfFn3/WEGcxuPkaaf8lAq9L+3nYg45GwGy4utH/Tnmg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -110,7 +110,7 @@ func selectShell(shell string) error {
 		}
 		return err
 	default:
-		return fmt.Errorf("Could not automatically detect your shell. Please run the command with the `--shell` flag for either bash or zsh")
+		return fmt.Errorf("could not automatically detect your shell. Please run the command with the `--shell` flag for either bash or zsh")
 	}
 }
 

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -88,9 +88,9 @@ func newListenCmd() *listenCmd {
 
 // listenCmd represents the listen command
 func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
-	var sourceAlias, connectionQuery string
+	var sourceQueryString, connectionQuery string
 	if len(args) > 1 {
-		sourceAlias = args[1]
+		sourceQueryString = args[1]
 	}
 	if len(args) > 2 {
 		connectionQuery = args[2]
@@ -112,7 +112,14 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		url.Scheme = "http"
 	}
 
-	return listen.Listen(url, sourceAlias, connectionQuery, listen.Flags{
+	var sourceQuery []string
+	if sourceQueryString == "" {
+		sourceQuery = []string{}
+	} else {
+		sourceQuery = strings.Split(sourceQueryString, ",")
+	}
+
+	return listen.Listen(url, sourceQuery, connectionQuery, listen.Flags{
 		NoWSS: lc.noWSS,
 	}, &Config)
 }

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -39,14 +39,14 @@ func newListenCmd() *listenCmd {
 		Use:   "listen",
 		Short: "Forward events for a source to your local server",
 		Long: `Forward events for a source to your local server.
-		
+
 This command will create a new Hookdeck Source if it doesn't exist.
 
-By default the Hookdeck Destination will be named "CLI",  and the
+By default the Hookdeck Destination will be named "CLI", and the
 Destination CLI path will be "/". To set the CLI path, use the "--cli-path" flag.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("Requires a port or forwarding URL to forward the events to")
+				return errors.New("requires a port or forwarding URL to forward the events to")
 			}
 
 			_, err_port := strconv.ParseInt(args[0], 10, 64)
@@ -60,21 +60,21 @@ Destination CLI path will be "/". To set the CLI path, use the "--cli-path" flag
 			}
 
 			if err_port != nil && err_url != nil {
-				return errors.New("Argument is not a valid port or forwading URL")
+				return errors.New("argument is not a valid port or forwading URL")
 			}
 
 			if err_port != nil {
 				if parsed_url.Host == "" {
-					return errors.New("Forwarding URL must contain a host.")
+					return errors.New("forwarding URL must contain a host")
 				}
 
 				if parsed_url.RawQuery != "" {
-					return errors.New("Forwarding URL cannot contain query params.")
+					return errors.New("forwarding URL cannot contain query params")
 				}
 			}
 
 			if len(args) > 3 {
-				return errors.New("Invalid extra argument provided")
+				return errors.New("invalid extra argument provided")
 			}
 
 			return nil

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -88,9 +88,9 @@ func newListenCmd() *listenCmd {
 
 // listenCmd represents the listen command
 func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
-	var sourceQueryString, connectionQuery string
+	var sourceQuery, connectionQuery string
 	if len(args) > 1 {
-		sourceQueryString = args[1]
+		sourceQuery = args[1]
 	}
 	if len(args) > 2 {
 		connectionQuery = args[2]
@@ -110,18 +110,6 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 
 	if url.Scheme == "" {
 		url.Scheme = "http"
-	}
-
-	var sourceQuery []string
-	if sourceQueryString == "" {
-		sourceQuery = []string{}
-	} else {
-		sourceQuery = strings.Split(sourceQueryString, ",")
-	}
-
-	// TODO: remove once we can support better limit
-	if len(sourceQuery) > 10 {
-		return errors.New("max 10 sources supported")
 	}
 
 	return listen.Listen(url, sourceQuery, connectionQuery, listen.Flags{

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -119,6 +119,11 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		sourceQuery = strings.Split(sourceQueryString, ",")
 	}
 
+	// TODO: remove once we can support better limit
+	if len(sourceQuery) > 10 {
+		return errors.New("max 10 sources supported")
+	}
+
 	return listen.Listen(url, sourceQuery, connectionQuery, listen.Flags{
 		NoWSS: lc.noWSS,
 	}, &Config)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -28,8 +28,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cfgFile string
-
 var Config config.Config
 
 var rootCmd = &cobra.Command{

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -11,8 +11,7 @@ import (
 )
 
 type whoamiCmd struct {
-	cmd         *cobra.Command
-	interactive bool
+	cmd *cobra.Command
 }
 
 func newWhoamiCmd() *whoamiCmd {

--- a/pkg/hookdeck/session.go
+++ b/pkg/hookdeck/session.go
@@ -29,7 +29,7 @@ func (c *Client) CreateSession(input CreateSessionInput) (Session, error) {
 	if res.StatusCode != http.StatusOK {
 		defer res.Body.Close()
 		body, _ := ioutil.ReadAll(res.Body)
-		return Session{}, fmt.Errorf("Unexpected http status code: %d %s", res.StatusCode, string(body))
+		return Session{}, fmt.Errorf("unexpected http status code: %d %s", res.StatusCode, string(body))
 	}
 	session := Session{}
 	postprocessJsonResponse(res, &session)

--- a/pkg/hookdeck/session.go
+++ b/pkg/hookdeck/session.go
@@ -13,7 +13,6 @@ type Session struct {
 }
 
 type CreateSessionInput struct {
-	SourceId      string   `json:"source_id"`
 	ConnectionIds []string `json:"webhook_ids"`
 }
 

--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -13,8 +13,20 @@ import (
 )
 
 func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source, connectionQuery string) ([]*hookdecksdk.Connection, error) {
-	source := sources[0]
+	connections := []*hookdecksdk.Connection{}
 
+	for _, source := range sources {
+		sourceConnections, err := getConnectionsPerSource(client, source, connectionQuery)
+		if err != nil {
+			return []*hookdecksdk.Connection{}, nil
+		}
+		connections = append(connections, sourceConnections...)
+	}
+
+	return connections, nil
+}
+
+func getConnectionsPerSource(client *hookdeckclient.Client, source *hookdecksdk.Source, connectionQuery string) ([]*hookdecksdk.Connection, error) {
 	// TODO: Filter connections using connectionQuery
 	var connections []*hookdecksdk.Connection
 	connectionList, err := client.Connection.List(context.Background(), &hookdecksdk.ConnectionListRequest{

--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -29,7 +29,7 @@ func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source
 func getConnectionsPerSource(client *hookdeckclient.Client, source *hookdecksdk.Source, connectionQuery string, isMultiSource bool) ([]*hookdecksdk.Connection, error) {
 	var connections []*hookdecksdk.Connection
 	connectionList, err := client.Connection.List(context.Background(), &hookdecksdk.ConnectionListRequest{
-		SourceId: &source.Id,
+		SourceId: []*string{&source.Id},
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -12,11 +12,11 @@ import (
 	hookdeckclient "github.com/hookdeck/hookdeck-go-sdk/client"
 )
 
-func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source, connectionQuery string) ([]*hookdecksdk.Connection, error) {
+func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source, connectionQuery string, isMultiSource bool) ([]*hookdecksdk.Connection, error) {
 	connections := []*hookdecksdk.Connection{}
 
 	for _, source := range sources {
-		sourceConnections, err := getConnectionsPerSource(client, source, connectionQuery)
+		sourceConnections, err := getConnectionsPerSource(client, source, connectionQuery, isMultiSource)
 		if err != nil {
 			return []*hookdecksdk.Connection{}, nil
 		}
@@ -26,7 +26,7 @@ func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source
 	return connections, nil
 }
 
-func getConnectionsPerSource(client *hookdeckclient.Client, source *hookdecksdk.Source, connectionQuery string) ([]*hookdecksdk.Connection, error) {
+func getConnectionsPerSource(client *hookdeckclient.Client, source *hookdecksdk.Source, connectionQuery string, isMultiSource bool) ([]*hookdecksdk.Connection, error) {
 	// TODO: Filter connections using connectionQuery
 	var connections []*hookdecksdk.Connection
 	connectionList, err := client.Connection.List(context.Background(), &hookdecksdk.ConnectionListRequest{
@@ -59,7 +59,7 @@ func getConnectionsPerSource(client *hookdeckclient.Client, source *hookdecksdk.
 		connections = filteredConnections
 	}
 
-	if len(connections) == 0 {
+	if len(connections) == 0 && !isMultiSource {
 		answers := struct {
 			Label string `survey:"label"`
 			Path  string `survey:"path"`

--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -27,7 +27,6 @@ func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source
 }
 
 func getConnectionsPerSource(client *hookdeckclient.Client, source *hookdecksdk.Source, connectionQuery string, isMultiSource bool) ([]*hookdecksdk.Connection, error) {
-	// TODO: Filter connections using connectionQuery
 	var connections []*hookdecksdk.Connection
 	connectionList, err := client.Connection.List(context.Background(), &hookdecksdk.ConnectionListRequest{
 		SourceId: &source.Id,

--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -12,7 +12,9 @@ import (
 	hookdeckclient "github.com/hookdeck/hookdeck-go-sdk/client"
 )
 
-func getConnections(client *hookdeckclient.Client, source *hookdecksdk.Source, connectionQuery string) ([]*hookdecksdk.Connection, error) {
+func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source, connectionQuery string) ([]*hookdecksdk.Connection, error) {
+	source := sources[0]
+
 	// TODO: Filter connections using connectionQuery
 	var connections []*hookdecksdk.Connection
 	connectionList, err := client.Connection.List(context.Background(), &hookdecksdk.ConnectionListRequest{

--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -45,13 +45,13 @@ func getConnectionsPerSource(client *hookdeckclient.Client, source *hookdecksdk.
 	connections = filteredConnections
 
 	if connectionQuery != "" {
-		is_path, err := isPath(connectionQuery)
+		isPath, err := isPath(connectionQuery)
 		if err != nil {
 			return connections, err
 		}
 		var filteredConnections []*hookdecksdk.Connection
 		for _, connection := range connections {
-			if (is_path && connection.Destination.CliPath != nil && strings.Contains(*connection.Destination.CliPath, connectionQuery)) || (connection.Name != nil && *connection.Name == connectionQuery) {
+			if (isPath && connection.Destination.CliPath != nil && strings.Contains(*connection.Destination.CliPath, connectionQuery)) || (connection.Name != nil && *connection.Name == connectionQuery) {
 				filteredConnections = append(filteredConnections, connection)
 			}
 		}
@@ -69,8 +69,8 @@ func getConnectionsPerSource(client *hookdeckclient.Client, source *hookdecksdk.
 				Prompt: &survey.Input{Message: "What path should the events be forwarded to (ie: /webhooks)?"},
 				Validate: func(val interface{}) error {
 					str, ok := val.(string)
-					is_path, err := isPath(str)
-					if !ok || !is_path || err != nil {
+					isPath, err := isPath(str)
+					if !ok || !isPath || err != nil {
 						return errors.New("invalid path")
 					}
 					return nil

--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -12,96 +12,101 @@ import (
 	hookdeckclient "github.com/hookdeck/hookdeck-go-sdk/client"
 )
 
-func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source, connectionQuery string, isMultiSource bool) ([]*hookdecksdk.Connection, error) {
-	connections := []*hookdecksdk.Connection{}
+func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source, connectionFilterString string, isMultiSource bool) ([]*hookdecksdk.Connection, error) {
+	sourceIDs := []*string{}
 
 	for _, source := range sources {
-		sourceConnections, err := getConnectionsPerSource(client, source, connectionQuery, isMultiSource)
-		if err != nil {
-			return []*hookdecksdk.Connection{}, nil
-		}
-		connections = append(connections, sourceConnections...)
+		sourceIDs = append(sourceIDs, &source.Id)
+	}
+
+	connectionQuery, err := client.Connection.List(context.Background(), &hookdecksdk.ConnectionListRequest{
+		SourceId: sourceIDs,
+	})
+	if err != nil {
+		return []*hookdecksdk.Connection{}, err
+	}
+
+	connections, err := filterConnections(connectionQuery.Models, connectionFilterString)
+	if err != nil {
+		return []*hookdecksdk.Connection{}, err
+	}
+
+	connections, err = ensureConnections(client, connections, sources, isMultiSource)
+	if err != nil {
+		return []*hookdecksdk.Connection{}, err
 	}
 
 	return connections, nil
 }
 
-func getConnectionsPerSource(client *hookdeckclient.Client, source *hookdecksdk.Source, connectionQuery string, isMultiSource bool) ([]*hookdecksdk.Connection, error) {
-	var connections []*hookdecksdk.Connection
-	connectionList, err := client.Connection.List(context.Background(), &hookdecksdk.ConnectionListRequest{
-		SourceId: []*string{&source.Id},
-	})
-	if err != nil {
-		return nil, err
+func filterConnections(connections []*hookdecksdk.Connection, connectionFilterString string) ([]*hookdecksdk.Connection, error) {
+	if connectionFilterString == "" {
+		return connections, nil
 	}
-	connections = connectionList.Models
 
+	isPath, err := isPath(connectionFilterString)
+	if err != nil {
+		return connections, err
+	}
 	var filteredConnections []*hookdecksdk.Connection
 	for _, connection := range connections {
-		if connection.Destination.CliPath != nil && *connection.Destination.CliPath != "" {
+		if (isPath && connection.Destination.CliPath != nil && strings.Contains(*connection.Destination.CliPath, connectionFilterString)) || (connection.Name != nil && *connection.Name == connectionFilterString) {
 			filteredConnections = append(filteredConnections, connection)
 		}
 	}
-	connections = filteredConnections
 
-	if connectionQuery != "" {
-		isPath, err := isPath(connectionQuery)
-		if err != nil {
-			return connections, err
-		}
-		var filteredConnections []*hookdecksdk.Connection
-		for _, connection := range connections {
-			if (isPath && connection.Destination.CliPath != nil && strings.Contains(*connection.Destination.CliPath, connectionQuery)) || (connection.Name != nil && *connection.Name == connectionQuery) {
-				filteredConnections = append(filteredConnections, connection)
-			}
-		}
-		connections = filteredConnections
+	return filteredConnections, nil
+}
+
+// When users want to listen to a single source but there is no connection for that source,
+// we can help user set up a new connection for it.
+func ensureConnections(client *hookdeckclient.Client, connections []*hookdecksdk.Connection, sources []*hookdecksdk.Source, isMultiSource bool) ([]*hookdecksdk.Connection, error) {
+	if len(connections) > 0 || isMultiSource {
+		return connections, nil
 	}
 
-	if len(connections) == 0 && !isMultiSource {
-		answers := struct {
-			Label string `survey:"label"`
-			Path  string `survey:"path"`
-		}{}
-		var qs = []*survey.Question{
-			{
-				Name:   "path",
-				Prompt: &survey.Input{Message: "What path should the events be forwarded to (ie: /webhooks)?"},
-				Validate: func(val interface{}) error {
-					str, ok := val.(string)
-					isPath, err := isPath(str)
-					if !ok || !isPath || err != nil {
-						return errors.New("invalid path")
-					}
-					return nil
-				},
+	answers := struct {
+		Label string `survey:"label"`
+		Path  string `survey:"path"`
+	}{}
+	var qs = []*survey.Question{
+		{
+			Name:   "path",
+			Prompt: &survey.Input{Message: "What path should the events be forwarded to (ie: /webhooks)?"},
+			Validate: func(val interface{}) error {
+				str, ok := val.(string)
+				isPath, err := isPath(str)
+				if !ok || !isPath || err != nil {
+					return errors.New("invalid path")
+				}
+				return nil
 			},
-			{
-				Name:     "label",
-				Prompt:   &survey.Input{Message: "What's your connection label (ie: My API)?"},
-				Validate: survey.Required,
-			},
-		}
-
-		err := survey.Ask(qs, &answers)
-		if err != nil {
-			fmt.Println(err.Error())
-			return connections, err
-		}
-		alias := slug.Make(answers.Label)
-		connection, err := client.Connection.Create(context.Background(), &hookdecksdk.ConnectionCreateRequest{
-			Name:     hookdecksdk.OptionalOrNull(&alias),
-			SourceId: hookdecksdk.OptionalOrNull(&source.Id),
-			Destination: hookdecksdk.OptionalOrNull(&hookdecksdk.ConnectionCreateRequestDestination{
-				Name:    alias,
-				CliPath: &answers.Path,
-			}),
-		})
-		if err != nil {
-			return connections, err
-		}
-		connections = append(connections, connection)
+		},
+		{
+			Name:     "label",
+			Prompt:   &survey.Input{Message: "What's your connection label (ie: My API)?"},
+			Validate: survey.Required,
+		},
 	}
+
+	err := survey.Ask(qs, &answers)
+	if err != nil {
+		fmt.Println(err.Error())
+		return connections, err
+	}
+	alias := slug.Make(answers.Label)
+	connection, err := client.Connection.Create(context.Background(), &hookdecksdk.ConnectionCreateRequest{
+		Name:     hookdecksdk.OptionalOrNull(&alias),
+		SourceId: hookdecksdk.OptionalOrNull(&sources[0].Id),
+		Destination: hookdecksdk.OptionalOrNull(&hookdecksdk.ConnectionCreateRequestDestination{
+			Name:    alias,
+			CliPath: &answers.Path,
+		}),
+	})
+	if err != nil {
+		return connections, err
+	}
+	connections = append(connections, connection)
 
 	return connections, nil
 }

--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -71,17 +71,13 @@ func filterConnections(connections []*hookdecksdk.Connection, connectionFilterSt
 // When users want to listen to a single source but there is no connection for that source,
 // we can help user set up a new connection for it.
 func ensureConnections(client *hookdeckclient.Client, connections []*hookdecksdk.Connection, sources []*hookdecksdk.Source, isMultiSource bool, connectionFilterString string, cliPath string) ([]*hookdecksdk.Connection, error) {
-	l := log.StandardLogger()
-
 	if len(connections) > 0 || isMultiSource {
-		msg := fmt.Sprintf("Connection exists for Source \"%s\", Connection \"%s\", and CLI path \"%s\"", sources[0].Name, connectionFilterString, cliPath)
-		l.Debug(msg)
+		log.Debug(fmt.Sprintf("Connection exists for Source \"%s\", Connection \"%s\", and CLI path \"%s\"", sources[0].Name, connectionFilterString, cliPath))
 
 		return connections, nil
 	}
 
-	msg := fmt.Sprintf("No connection found. Creating a connection for Source \"%s\", Connection \"%s\", and CLI path \"%s\"", sources[0].Name, connectionFilterString, cliPath)
-	l.Debug(msg)
+	log.Debug(fmt.Sprintf("No connection found. Creating a connection for Source \"%s\", Connection \"%s\", and CLI path \"%s\"", sources[0].Name, connectionFilterString, cliPath))
 
 	connectionDetails := struct {
 		Label string `survey:"label"`

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/hookdeck/hookdeck-cli/pkg/config"
 	"github.com/hookdeck/hookdeck-cli/pkg/login"
@@ -34,9 +35,14 @@ type Flags struct {
 }
 
 // listenCmd represents the listen command
-func Listen(URL *url.URL, sourceAliases []string, connectionQuery string, flags Flags, config *config.Config) error {
+func Listen(URL *url.URL, sourceQuery string, connectionQuery string, flags Flags, config *config.Config) error {
 	var err error
 	var guestURL string
+
+	sourceAliases, err := parseSourceQuery(sourceQuery)
+	if err != nil {
+		return err
+	}
 
 	isMultiSource := len(sourceAliases) > 1 || (len(sourceAliases) == 1 && sourceAliases[0] == "*")
 
@@ -98,6 +104,22 @@ func Listen(URL *url.URL, sourceAliases []string, connectionQuery string, flags 
 	}
 
 	return nil
+}
+
+func parseSourceQuery(sourceQuery string) ([]string, error) {
+	var sourceAliases []string
+	if sourceQuery == "" {
+		sourceAliases = []string{}
+	} else {
+		sourceAliases = strings.Split(sourceQuery, ",")
+	}
+
+	// TODO: remove once we can support better limit
+	if len(sourceAliases) > 10 {
+		return []string{}, errors.New("max 10 sources supported")
+	}
+
+	return sourceAliases, nil
 }
 
 func isPath(value string) (bool, error) {

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -17,6 +17,7 @@ package listen
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -24,6 +25,7 @@ import (
 	"github.com/hookdeck/hookdeck-cli/pkg/config"
 	"github.com/hookdeck/hookdeck-cli/pkg/login"
 	"github.com/hookdeck/hookdeck-cli/pkg/proxy"
+	hookdecksdk "github.com/hookdeck/hookdeck-go-sdk"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -45,6 +47,8 @@ func Listen(URL *url.URL, sourceAliases []string, connectionQuery string, flags 
 
 	sdkClient := config.GetClient()
 
+	// Prepare data
+
 	sources, err := getSources(sdkClient, sourceAliases)
 	if err != nil {
 		return err
@@ -54,6 +58,12 @@ func Listen(URL *url.URL, sourceAliases []string, connectionQuery string, flags 
 	if err != nil {
 		return err
 	}
+
+	if err := validateData(sources, connections); err != nil {
+		return err
+	}
+
+	// Start proxy
 
 	fmt.Println()
 	printDashboardInformation(config, guestURL)
@@ -89,4 +99,12 @@ func Listen(URL *url.URL, sourceAliases []string, connectionQuery string, flags 
 func isPath(value string) (bool, error) {
 	is_path, err := regexp.MatchString(`^(\/)+([/a-zA-Z0-9-_%\.\-\_\~\!\$\&\'\(\)\*\+\,\;\=\:\@]*)$`, value)
 	return is_path, err
+}
+
+func validateData(sources []*hookdecksdk.Source, connections []*hookdecksdk.Connection) error {
+	if len(connections) == 0 {
+		return errors.New("no connections provided")
+	}
+
+	return nil
 }

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hookdeck/hookdeck-cli/pkg/config"
 	"github.com/hookdeck/hookdeck-cli/pkg/login"
 	"github.com/hookdeck/hookdeck-cli/pkg/proxy"
-	hookdecksdk "github.com/hookdeck/hookdeck-go-sdk"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -33,7 +32,7 @@ type Flags struct {
 }
 
 // listenCmd represents the listen command
-func Listen(URL *url.URL, sourceAlias string, connectionQuery string, flags Flags, config *config.Config) error {
+func Listen(URL *url.URL, sourceAliases []string, connectionQuery string, flags Flags, config *config.Config) error {
 	var err error
 	var guestURL string
 
@@ -46,13 +45,12 @@ func Listen(URL *url.URL, sourceAlias string, connectionQuery string, flags Flag
 
 	sdkClient := config.GetClient()
 
-	source, err := getSource(sdkClient, sourceAlias)
+	sources, err := getSources(sdkClient, sourceAliases)
 	if err != nil {
 		return err
 	}
-	sources := []*hookdecksdk.Source{source}
 
-	connections, err := getConnections(sdkClient, source, connectionQuery)
+	connections, err := getConnections(sdkClient, sources, connectionQuery)
 	if err != nil {
 		return err
 	}

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -110,8 +110,16 @@ func parseSourceQuery(sourceQuery string) ([]string, error) {
 	var sourceAliases []string
 	if sourceQuery == "" {
 		sourceAliases = []string{}
-	} else {
+	} else if strings.Contains(sourceQuery, ",") {
 		sourceAliases = strings.Split(sourceQuery, ",")
+	} else if strings.Contains(sourceQuery, " ") {
+		sourceAliases = strings.Split(sourceQuery, " ")
+	} else {
+		sourceAliases = append(sourceAliases, sourceQuery)
+	}
+
+	for i := range sourceAliases {
+		sourceAliases[i] = strings.TrimSpace(sourceAliases[i])
 	}
 
 	// TODO: remove once we can support better limit

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -38,6 +38,8 @@ func Listen(URL *url.URL, sourceAliases []string, connectionQuery string, flags 
 	var err error
 	var guestURL string
 
+	isMultiSource := len(sourceAliases) > 1 || (len(sourceAliases) == 1 && sourceAliases[0] == "*")
+
 	if config.Profile.APIKey == "" {
 		guestURL, err = login.GuestLogin(config)
 		if guestURL == "" {
@@ -54,7 +56,7 @@ func Listen(URL *url.URL, sourceAliases []string, connectionQuery string, flags 
 		return err
 	}
 
-	connections, err := getConnections(sdkClient, sources, connectionQuery)
+	connections, err := getConnections(sdkClient, sources, connectionQuery, isMultiSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -100,7 +100,7 @@ Specify a single destination to update the CLI path. For example, pass a connect
 
 		path := flags.CliPath
 		_, err := sdkClient.Destination.Update(context.Background(), connections[0].Destination.Id, &hookdecksdk.DestinationUpdateRequest{
-			CliPath: hookdecksdk.Optional[string](path),
+			CliPath: hookdecksdk.Optional(path),
 		})
 
 		if err != nil {

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -52,8 +52,11 @@ func Listen(URL *url.URL, sourceQuery string, connectionFilterString string, fla
 			return errors.New("Can only set a CLI path when listening to a single source")
 		}
 
-		_, err = isPath(flags.CliPath)
+		flagIsPath, err := isPath(flags.CliPath)
 		if err != nil {
+			return err
+		}
+		if !flagIsPath {
 			return errors.New("The CLI path must be in a valid format")
 		}
 	}

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -95,9 +95,8 @@ Specify a single destination to update the CLI path. For example, pass a connect
 		*connections[0].Destination.CliPath != "" &&
 		*connections[0].Destination.CliPath != flags.CliPath {
 
-		l := log.StandardLogger()
 		updateMsg := fmt.Sprintf("Updating destination CLI path from \"%s\" to \"%s\"", *connections[0].Destination.CliPath, flags.CliPath)
-		l.Debug(updateMsg)
+		log.Debug(updateMsg)
 
 		path := flags.CliPath
 		_, err := sdkClient.Destination.Update(context.Background(), connections[0].Destination.Id, &hookdecksdk.DestinationUpdateRequest{

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -35,7 +35,7 @@ type Flags struct {
 }
 
 // listenCmd represents the listen command
-func Listen(URL *url.URL, sourceQuery string, connectionQuery string, flags Flags, config *config.Config) error {
+func Listen(URL *url.URL, sourceQuery string, connectionFilterString string, flags Flags, config *config.Config) error {
 	var err error
 	var guestURL string
 
@@ -62,7 +62,7 @@ func Listen(URL *url.URL, sourceQuery string, connectionQuery string, flags Flag
 		return err
 	}
 
-	connections, err := getConnections(sdkClient, sources, connectionQuery, isMultiSource)
+	connections, err := getConnections(sdkClient, sources, connectionFilterString, isMultiSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -83,7 +83,7 @@ func Listen(URL *url.URL, sourceQuery string, connectionFilterString string, fla
 		return errors.New(fmt.Errorf(`Multiple CLI destinations found. Cannot set the CLI path on multiple destinations.
 Specify a single destination to update the CLI path. For example, pass a connection name:
 			
-  hookdeck listen %s %s %s --cli-path %s`, URL.String(), sourceQuery, "connection-name", flags.CliPath).Error())
+  hookdeck listen %s %s %s --cli-path %s`, URL.String(), sources[0].Name, "connection-name", flags.CliPath).Error())
 	}
 
 	// If the "cli-path" flag has been passed and the destination has a current cli path value but it's different, update destination path

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -74,7 +74,7 @@ func Listen(URL *url.URL, sourceQuery string, connectionFilterString string, fla
 	}
 
 	// Start proxy
-	printListenMessage(config, sourceQuery, isMultiSource)
+	printListenMessage(config, isMultiSource)
 	fmt.Println()
 	printDashboardInformation(config, guestURL)
 	fmt.Println()

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -74,7 +74,7 @@ func Listen(URL *url.URL, sourceQuery string, connectionFilterString string, fla
 	}
 
 	// Start proxy
-
+	printListenMessage(config, sourceQuery, isMultiSource)
 	fmt.Println()
 	printDashboardInformation(config, guestURL)
 	fmt.Println()

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -61,6 +61,8 @@ func Listen(URL *url.URL, sourceAliases []string, connectionQuery string, flags 
 		return err
 	}
 
+	sources = getRelevantSources(sources, connections)
+
 	if err := validateData(sources, connections); err != nil {
 		return err
 	}
@@ -109,4 +111,22 @@ func validateData(sources []*hookdecksdk.Source, connections []*hookdecksdk.Conn
 	}
 
 	return nil
+}
+
+func getRelevantSources(sources []*hookdecksdk.Source, connections []*hookdecksdk.Connection) []*hookdecksdk.Source {
+	relevantSourceId := map[string]bool{}
+
+	for _, connection := range connections {
+		relevantSourceId[connection.Source.Id] = true
+	}
+
+	relevantSources := []*hookdecksdk.Source{}
+
+	for _, source := range sources {
+		if relevantSourceId[source.Id] {
+			relevantSources = append(relevantSources, source)
+		}
+	}
+
+	return relevantSources
 }

--- a/pkg/listen/printer.go
+++ b/pkg/listen/printer.go
@@ -8,6 +8,19 @@ import (
 	hookdecksdk "github.com/hookdeck/hookdeck-go-sdk"
 )
 
+func printListenMessage(config *config.Config, sourceQuery string, isMultiSource bool) {
+	if !isMultiSource {
+		return
+	}
+
+	fmt.Println()
+	if sourceQuery == "*" {
+		fmt.Println("Listening for events on the first 10 Sources that have Connections with CLI Destinations")
+	} else {
+		fmt.Println("Listening for events on Sources that have Connections with CLI Destinations")
+	}
+}
+
 func printDashboardInformation(config *config.Config, guestURL string) {
 	fmt.Println(ansi.Bold("Dashboard"))
 	if guestURL != "" {

--- a/pkg/listen/printer.go
+++ b/pkg/listen/printer.go
@@ -20,8 +20,6 @@ func printDashboardInformation(config *config.Config, guestURL string) {
 			url += "?team_id=" + config.Profile.TeamID
 		}
 		if config.Profile.TeamMode == "console" {
-			// TODO: how should we display this if there are multiple sources?
-			// url = config.ConsoleBaseURL + "?source_id=" + source.Id
 			url = config.ConsoleBaseURL
 		}
 		fmt.Println("👉 Inspect and replay events: " + url)

--- a/pkg/listen/printer.go
+++ b/pkg/listen/printer.go
@@ -9,16 +9,12 @@ import (
 )
 
 func printListenMessage(config *config.Config, sourceQuery string, isMultiSource bool) {
-	if !isMultiSource {
+	if !isMultiSource || sourceQuery == "*" {
 		return
 	}
 
 	fmt.Println()
-	if sourceQuery == "*" {
-		fmt.Println("Listening for events on the first 10 Sources that have Connections with CLI Destinations")
-	} else {
-		fmt.Println("Listening for events on Sources that have Connections with CLI Destinations")
-	}
+	fmt.Println("Listening for events on Sources that have Connections with CLI Destinations")
 }
 
 func printDashboardInformation(config *config.Config, guestURL string) {

--- a/pkg/listen/printer.go
+++ b/pkg/listen/printer.go
@@ -1,0 +1,44 @@
+package listen
+
+import (
+	"fmt"
+
+	"github.com/hookdeck/hookdeck-cli/pkg/ansi"
+	"github.com/hookdeck/hookdeck-cli/pkg/config"
+	hookdecksdk "github.com/hookdeck/hookdeck-go-sdk"
+)
+
+func printDashboardInformation(config *config.Config, guestURL string) {
+	fmt.Println(ansi.Bold("Dashboard"))
+	if guestURL != "" {
+		fmt.Println("👤 Console URL: " + guestURL)
+		fmt.Println("Sign up in the Console to make your webhook URL permanent.")
+		fmt.Println()
+	} else {
+		var url = config.DashboardBaseURL
+		if config.Profile.TeamID != "" {
+			url += "?team_id=" + config.Profile.TeamID
+		}
+		if config.Profile.TeamMode == "console" {
+			// TODO: how should we display this if there are multiple sources?
+			// url = config.ConsoleBaseURL + "?source_id=" + source.Id
+			url = config.ConsoleBaseURL
+		}
+		fmt.Println("👉 Inspect and replay events: " + url)
+	}
+}
+
+func printSources(config *config.Config, sources []*hookdecksdk.Source) {
+	fmt.Println(ansi.Bold("Sources"))
+
+	for _, source := range sources {
+		fmt.Printf("🔌 %s URL: %s\n", source.Name, source.Url)
+	}
+}
+
+func printConnections(config *config.Config, connections []*hookdecksdk.Connection) {
+	fmt.Println(ansi.Bold("Connections"))
+	for _, connection := range connections {
+		fmt.Println(*connection.FullName + " forwarding to " + *connection.Destination.CliPath)
+	}
+}

--- a/pkg/listen/printer.go
+++ b/pkg/listen/printer.go
@@ -8,8 +8,8 @@ import (
 	hookdecksdk "github.com/hookdeck/hookdeck-go-sdk"
 )
 
-func printListenMessage(config *config.Config, sourceQuery string, isMultiSource bool) {
-	if !isMultiSource || sourceQuery == "*" {
+func printListenMessage(config *config.Config, isMultiSource bool) {
+	if !isMultiSource {
 		return
 	}
 

--- a/pkg/listen/source.go
+++ b/pkg/listen/source.go
@@ -28,15 +28,11 @@ import (
 // they'd like to use. They will also have an option to create a new source.
 
 func getSources(sdkClient *hookdeckclient.Client, sourceQuery []string) ([]*hookdecksdk.Source, error) {
-	limit := 100
+	limit := 255 // Hookdeck API limit
 
 	// case 1
 	if len(sourceQuery) == 1 && sourceQuery[0] == "*" {
-		// TODO: remove once we can support better limit
-		temporaryLimit := 10
-		sources, err := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{
-			Limit: &temporaryLimit,
-		})
+		sources, err := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{})
 		if err != nil {
 			return []*hookdecksdk.Source{}, err
 		}

--- a/pkg/listen/source.go
+++ b/pkg/listen/source.go
@@ -75,9 +75,13 @@ func getSources(sdkClient *hookdeckclient.Client, sourceQuery []string) ([]*hook
 	} else {
 		sources := []*hookdecksdk.Source{}
 
-		availableSources, _ := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{
+		availableSources, err := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{
 			Limit: &limit,
 		})
+
+		if err != nil {
+			return []*hookdecksdk.Source{}, err
+		}
 
 		if *availableSources.Count > 0 {
 			selectedSources, err := selectSources(availableSources.Models)

--- a/pkg/listen/source.go
+++ b/pkg/listen/source.go
@@ -2,6 +2,7 @@ package listen
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -10,27 +11,31 @@ import (
 	hookdeckclient "github.com/hookdeck/hookdeck-go-sdk/client"
 )
 
-func getSource(sdkClient *hookdeckclient.Client, source_alias string) (*hookdecksdk.Source, error) {
+func getSources(sdkClient *hookdeckclient.Client, sourceQuery []string) ([]*hookdecksdk.Source, error) {
+	limit := 100
 	var source *hookdecksdk.Source
-	if source_alias != "" {
-		sources, _ := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{
-			Name: &source_alias,
+	if len(sourceQuery) == 1 && sourceQuery[0] == "*" {
+		sources, err := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{
+			Limit: &limit,
 		})
-		if *sources.Count > 0 {
-			source = sources.Models[0]
+		if err != nil {
+			return []*hookdecksdk.Source{}, err
 		}
-		if source == nil {
-			// TODO: Prompt here?
-			source, _ = sdkClient.Source.Create(context.Background(), &hookdecksdk.SourceCreateRequest{
-				Name: slug.Make(source_alias),
-			})
+		if sources == nil || *sources.Count == 0 {
+			return []*hookdecksdk.Source{}, errors.New("unable to find any matching sources")
 		}
+		return sources.Models, nil
+	} else if len(sourceQuery) > 0 {
+		return listMultipleSources(sdkClient, sourceQuery)
 	} else {
-		sources, _ := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{})
-		if *sources.Count > 0 {
-			var sources_alias []string
-			for _, temp_source := range sources.Models {
-				sources_alias = append(sources_alias, temp_source.Name)
+		sources := []*hookdecksdk.Source{}
+		availableSources, _ := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{
+			Limit: &limit,
+		})
+		if *availableSources.Count > 0 {
+			var sourceAliases []string
+			for _, temp_source := range availableSources.Models {
+				sourceAliases = append(sourceAliases, temp_source.Name)
 			}
 
 			answers := struct {
@@ -42,7 +47,7 @@ func getSource(sdkClient *hookdeckclient.Client, source_alias string) (*hookdeck
 					Name: "source",
 					Prompt: &survey.Select{
 						Message: "Select a source",
-						Options: append(sources_alias, "Create new source"),
+						Options: append(sourceAliases, "Create new source"),
 					},
 				},
 			}
@@ -50,19 +55,19 @@ func getSource(sdkClient *hookdeckclient.Client, source_alias string) (*hookdeck
 			err := survey.Ask(qs, &answers)
 			if err != nil {
 				fmt.Println(err.Error())
-				return source, err
+				return []*hookdecksdk.Source{}, err
 			}
 
 			if answers.SourceAlias != "Create new source" {
-				for _, temp_source := range sources.Models {
-					if temp_source.Name == answers.SourceAlias {
-						source = temp_source
+				for _, currentSource := range availableSources.Models {
+					if currentSource.Name == answers.SourceAlias {
+						sources = append(sources, currentSource)
 					}
 				}
 			}
 		}
 
-		if source == nil {
+		if len(sources) == 0 {
 			answers := struct {
 				Label string `survey:"label"` // or you can tag fields to match a specific name
 			}{}
@@ -76,13 +81,33 @@ func getSource(sdkClient *hookdeckclient.Client, source_alias string) (*hookdeck
 
 			err := survey.Ask(qs, &answers)
 			if err != nil {
-				return source, err
+				return []*hookdecksdk.Source{}, err
 			}
 
 			source, _ = sdkClient.Source.Create(context.Background(), &hookdecksdk.SourceCreateRequest{
 				Name: slug.Make(answers.Label),
 			})
+			sources = append(sources, source)
+		}
+
+		return sources, nil
+	}
+}
+
+func listMultipleSources(sdkClient *hookdeckclient.Client, sourceQuery []string) ([]*hookdecksdk.Source, error) {
+	sources := []*hookdecksdk.Source{}
+
+	for _, sourceName := range sourceQuery {
+		sourceQuery, err := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{
+			Name: &sourceName,
+		})
+		if err != nil {
+			return []*hookdecksdk.Source{}, err
+		}
+		if len(sourceQuery.Models) > 0 {
+			sources = append(sources, sourceQuery.Models[0])
 		}
 	}
-	return source, nil
+
+	return sources, nil
 }

--- a/pkg/listen/source.go
+++ b/pkg/listen/source.go
@@ -11,9 +11,26 @@ import (
 	hookdeckclient "github.com/hookdeck/hookdeck-go-sdk/client"
 )
 
+// There are 4 cases:
+//
+// 1. search all sources (query string == '*')
+// 2. search multiple sources
+// 3. search 1 source
+// 4. no specific source
+//
+// For case 1 & 2, we'll simply query the sources data and return.
+// If no source is found, we'll show an error message and exit.
+//
+// For case 3, we'll search for the 1 source.
+// If that source is not found, we'll create it and move forward.
+//
+// For case 4, we'll get available sources and ask the user which ones
+// they'd like to use. They will also have an option to create a new source.
+
 func getSources(sdkClient *hookdeckclient.Client, sourceQuery []string) ([]*hookdecksdk.Source, error) {
 	limit := 100
-	var source *hookdecksdk.Source
+
+	// case 1
 	if len(sourceQuery) == 1 && sourceQuery[0] == "*" {
 		// TODO: remove once we can support better limit
 		temporaryLimit := 10
@@ -26,73 +43,59 @@ func getSources(sdkClient *hookdeckclient.Client, sourceQuery []string) ([]*hook
 		if sources == nil || *sources.Count == 0 {
 			return []*hookdecksdk.Source{}, errors.New("unable to find any matching sources")
 		}
-		return sources.Models, nil
-	} else if len(sourceQuery) > 0 {
-		return listMultipleSources(sdkClient, sourceQuery)
+		return validateSources(sources.Models)
+
+		// case 2
+	} else if len(sourceQuery) > 1 {
+		searchedSources, err := listMultipleSources(sdkClient, sourceQuery)
+		if err != nil {
+			return []*hookdecksdk.Source{}, err
+		}
+		return validateSources(searchedSources)
+
+		// case 3
+	} else if len(sourceQuery) == 1 {
+		searchedSources, err := listMultipleSources(sdkClient, sourceQuery)
+		if err != nil {
+			return []*hookdecksdk.Source{}, err
+		}
+		if len(searchedSources) > 0 {
+			return validateSources(searchedSources)
+		}
+
+		// Create source with provided name
+		source, err := createSource(sdkClient, &sourceQuery[0])
+		if err != nil {
+			return []*hookdecksdk.Source{}, err
+		}
+
+		return validateSources([]*hookdecksdk.Source{source})
+
+		// case 4
 	} else {
 		sources := []*hookdecksdk.Source{}
+
 		availableSources, _ := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{
 			Limit: &limit,
 		})
+
 		if *availableSources.Count > 0 {
-			var sourceAliases []string
-			for _, temp_source := range availableSources.Models {
-				sourceAliases = append(sourceAliases, temp_source.Name)
-			}
-
-			answers := struct {
-				SourceAlias string `survey:"source"`
-			}{}
-
-			var qs = []*survey.Question{
-				{
-					Name: "source",
-					Prompt: &survey.Select{
-						Message: "Select a source",
-						Options: append(sourceAliases, "Create new source"),
-					},
-				},
-			}
-
-			err := survey.Ask(qs, &answers)
+			selectedSources, err := selectSources(availableSources.Models)
 			if err != nil {
-				fmt.Println(err.Error())
 				return []*hookdecksdk.Source{}, err
 			}
-
-			if answers.SourceAlias != "Create new source" {
-				for _, currentSource := range availableSources.Models {
-					if currentSource.Name == answers.SourceAlias {
-						sources = append(sources, currentSource)
-					}
-				}
-			}
+			sources = append(sources, selectedSources...)
 		}
 
 		if len(sources) == 0 {
-			answers := struct {
-				Label string `survey:"label"` // or you can tag fields to match a specific name
-			}{}
-			var qs = []*survey.Question{
-				{
-					Name:     "label",
-					Prompt:   &survey.Input{Message: "What should be your new source label?"},
-					Validate: survey.Required,
-				},
-			}
-
-			err := survey.Ask(qs, &answers)
+			source, err := createSource(sdkClient, nil)
 			if err != nil {
 				return []*hookdecksdk.Source{}, err
 			}
-
-			source, _ = sdkClient.Source.Create(context.Background(), &hookdecksdk.SourceCreateRequest{
-				Name: slug.Make(answers.Label),
-			})
 			sources = append(sources, source)
 		}
 
-		return sources, nil
+		return validateSources(sources)
 	}
 }
 
@@ -109,6 +112,84 @@ func listMultipleSources(sdkClient *hookdeckclient.Client, sourceQuery []string)
 		if len(sourceQuery.Models) > 0 {
 			sources = append(sources, sourceQuery.Models[0])
 		}
+	}
+
+	return sources, nil
+}
+
+func selectSources(availableSources []*hookdecksdk.Source) ([]*hookdecksdk.Source, error) {
+	sources := []*hookdecksdk.Source{}
+
+	var sourceAliases []string
+	for _, temp_source := range availableSources {
+		sourceAliases = append(sourceAliases, temp_source.Name)
+	}
+
+	answers := struct {
+		SourceAlias string `survey:"source"`
+	}{}
+
+	var qs = []*survey.Question{
+		{
+			Name: "source",
+			Prompt: &survey.Select{
+				Message: "Select a source",
+				Options: append(sourceAliases, "Create new source"),
+			},
+		},
+	}
+
+	err := survey.Ask(qs, &answers)
+	if err != nil {
+		fmt.Println(err.Error())
+		return []*hookdecksdk.Source{}, err
+	}
+
+	if answers.SourceAlias != "Create new source" {
+		for _, currentSource := range availableSources {
+			if currentSource.Name == answers.SourceAlias {
+				sources = append(sources, currentSource)
+			}
+		}
+	}
+
+	return sources, nil
+}
+
+func createSource(sdkClient *hookdeckclient.Client, name *string) (*hookdecksdk.Source, error) {
+	var sourceName string
+
+	if name != nil {
+		sourceName = *name
+	} else {
+		answers := struct {
+			Label string `survey:"label"` // or you can tag fields to match a specific name
+		}{}
+		var qs = []*survey.Question{
+			{
+				Name:     "label",
+				Prompt:   &survey.Input{Message: "What should be your new source label?"},
+				Validate: survey.Required,
+			},
+		}
+
+		err := survey.Ask(qs, &answers)
+		if err != nil {
+			return nil, err
+		}
+		sourceName = answers.Label
+	}
+
+	source, err := sdkClient.Source.Create(context.Background(), &hookdecksdk.SourceCreateRequest{
+		Name: slug.Make(sourceName),
+	})
+
+	return source, err
+}
+
+func validateSources(sources []*hookdecksdk.Source) ([]*hookdecksdk.Source, error) {
+	if len(sources) == 0 {
+		return []*hookdecksdk.Source{}, errors.New("unable to find any matching sources")
 	}
 
 	return sources, nil

--- a/pkg/listen/source.go
+++ b/pkg/listen/source.go
@@ -15,8 +15,10 @@ func getSources(sdkClient *hookdeckclient.Client, sourceQuery []string) ([]*hook
 	limit := 100
 	var source *hookdecksdk.Source
 	if len(sourceQuery) == 1 && sourceQuery[0] == "*" {
+		// TODO: remove once we can support better limit
+		temporaryLimit := 10
 		sources, err := sdkClient.Source.List(context.Background(), &hookdecksdk.SourceListRequest{
-			Limit: &limit,
+			Limit: &temporaryLimit,
 		})
 		if err != nil {
 			return []*hookdecksdk.Source{}, err

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -214,14 +214,16 @@ func (p *Proxy) createSession(ctx context.Context) (hookdeck.Session, error) {
 		TeamID:  p.cfg.TeamID,
 	}
 
-	var connection_ids []string
+	var connectionIDs []string
 	for _, connection := range p.connections {
-		connection_ids = append(connection_ids, connection.Id)
+		connectionIDs = append(connectionIDs, connection.Id)
 	}
 
 	for i := 0; i <= 5; i++ {
-		session, err = client.CreateSession(hookdeck.CreateSessionInput{SourceId: p.source.Id,
-			ConnectionIds: connection_ids})
+		session, err = client.CreateSession(hookdeck.CreateSessionInput{
+			SourceId:      p.source.Id,
+			ConnectionIds: connectionIDs,
+		})
 
 		if err == nil {
 			return session, nil


### PR DESCRIPTION
Adds support for:

## Listening on multiple sources #70

```
$ hookdeck listen 1234 source-1,source-2
```

```
$ hookdeck listen 1234 '*'
```

__Notes__: Based on the way our CLI processes argument, when running `hookdeck listen 1234 *`, it will pass every files in the directory as arguments, causing a validation issue. Therefore, we need to do `hookdeck listen 1234 '*'` for it to work. Curious what yall think about this. It may make more sense to change it to a flag like `hookdeck listen 1234 --all` or `hookdeck listen 1234 --all-source`.

## Defaults for optional `listen` command `connection` and `path` arguments

This removes the interactivity prompts for the connection "label" and "path".

See #92.

## Ability to set the CLI Path using `--cli-path` flag

See #92. 