### PR TITLE
Adds --cli-path and changes behavior to remove connection name and path terminal interactivity

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -26,9 +26,9 @@ import (
 )
 
 type listenCmd struct {
-	cmd       *cobra.Command
-	wsBaseURL string
-	noWSS     bool
+	cmd   *cobra.Command
+	noWSS bool
+	path  string
 }
 
 func newListenCmd() *listenCmd {
@@ -75,6 +75,7 @@ func newListenCmd() *listenCmd {
 		RunE: lc.runListenCmd,
 	}
 	lc.cmd.Flags().BoolVar(&lc.noWSS, "no-wss", false, "Force unencrypted ws:// protocol instead of wss://")
+	lc.cmd.Flags().StringVar(&lc.path, "cli-path", "", "Sets the server path of that locally running web server the events will be forwarded to")
 
 	lc.cmd.SetUsageTemplate(
 		strings.Replace(
@@ -113,6 +114,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	return listen.Listen(url, sourceQuery, connectionQuery, listen.Flags{
-		NoWSS: lc.noWSS,
+		NoWSS:   lc.noWSS,
+		CliPath: lc.path,
 	}, &Config)
 }

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -26,9 +27,9 @@ import (
 )
 
 type listenCmd struct {
-	cmd   *cobra.Command
-	noWSS bool
-	path  string
+	cmd     *cobra.Command
+	noWSS   bool
+	cliPath string
 }
 
 func newListenCmd() *listenCmd {
@@ -37,6 +38,12 @@ func newListenCmd() *listenCmd {
 	lc.cmd = &cobra.Command{
 		Use:   "listen",
 		Short: "Forward events for a source to your local server",
+		Long: `Forward events for a source to your local server.
+		
+This command will create a new Hookdeck Source if it doesn't exist.
+
+By default the Hookdeck Destination will be named "CLI",  and the
+Destination CLI path will be "/". To set the CLI path, use the "--cli-path" flag.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Requires a port or forwarding URL to forward the events to")
@@ -75,14 +82,41 @@ func newListenCmd() *listenCmd {
 		RunE: lc.runListenCmd,
 	}
 	lc.cmd.Flags().BoolVar(&lc.noWSS, "no-wss", false, "Force unencrypted ws:// protocol instead of wss://")
-	lc.cmd.Flags().StringVar(&lc.path, "cli-path", "", "Sets the server path of that locally running web server the events will be forwarded to")
+	lc.cmd.Flags().MarkHidden("no-wss")
+	lc.cmd.Flags().StringVar(&lc.cliPath, "cli-path", "", "Sets the server path of that locally running web server the events will be forwarded to")
 
-	lc.cmd.SetUsageTemplate(
-		strings.Replace(
-			lc.cmd.UsageTemplate(),
-			"{{.UseLine}}",
-			"hookdeck listen [port or forwarding URL] [source] [connection] [flags]", 1),
-	)
+	usage := lc.cmd.UsageTemplate()
+
+	usage = strings.Replace(
+		usage,
+		"{{.UseLine}}",
+		`hookdeck listen [port or forwarding URL] [source] [connection] [flags]
+
+Arguments:
+
+ - [port or forwarding URL]: Required. The port or forwarding URL to forward the events to e.g., "3000" or "http://localhost:3000"
+ - [source]: Required. The name of source to forward the events from e.g., "shopify", "stripe"
+ - [connection]: Optional. The name of the connection linking the Source and the Destination
+	`, 1)
+
+	usage += fmt.Sprintf(`
+	
+Examples:
+
+  Forward events from a Hookdeck Source named "shopify" to a local server running on port %[1]d:
+
+    hookdeck listen %[1]d shopify
+		
+  Forward events to a local server running on "http://myapp.test":
+
+    hookdeck listen %[1]d http://myapp.test
+	
+  Forward events to the path "/webhooks" on local server running on port %[1]d:
+
+    hookdeck listen %[1]d --cli-path /webhooks
+		`, 3000)
+
+	lc.cmd.SetUsageTemplate(usage)
 
 	return lc
 }
@@ -115,6 +149,6 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 
 	return listen.Listen(url, sourceQuery, connectionQuery, listen.Flags{
 		NoWSS:   lc.noWSS,
-		CliPath: lc.path,
+		CliPath: lc.cliPath,
 	}, &Config)
 }

--- a/pkg/listen/connection.go
+++ b/pkg/listen/connection.go
@@ -2,14 +2,13 @@ package listen
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/gosimple/slug"
 	hookdecksdk "github.com/hookdeck/hookdeck-go-sdk"
 	hookdeckclient "github.com/hookdeck/hookdeck-go-sdk/client"
+	log "github.com/sirupsen/logrus"
 )
 
 func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source, connectionFilterString string, isMultiSource bool, cliPath string) ([]*hookdecksdk.Connection, error) {
@@ -31,7 +30,7 @@ func getConnections(client *hookdeckclient.Client, sources []*hookdecksdk.Source
 		return []*hookdecksdk.Connection{}, err
 	}
 
-	connections, err = ensureConnections(client, connections, sources, isMultiSource, cliPath)
+	connections, err = ensureConnections(client, connections, sources, isMultiSource, connectionFilterString, cliPath)
 	if err != nil {
 		return []*hookdecksdk.Connection{}, err
 	}
@@ -71,45 +70,34 @@ func filterConnections(connections []*hookdecksdk.Connection, connectionFilterSt
 
 // When users want to listen to a single source but there is no connection for that source,
 // we can help user set up a new connection for it.
-func ensureConnections(client *hookdeckclient.Client, connections []*hookdecksdk.Connection, sources []*hookdecksdk.Source, isMultiSource bool, cliPath string) ([]*hookdecksdk.Connection, error) {
+func ensureConnections(client *hookdeckclient.Client, connections []*hookdecksdk.Connection, sources []*hookdecksdk.Source, isMultiSource bool, connectionFilterString string, cliPath string) ([]*hookdecksdk.Connection, error) {
+	l := log.StandardLogger()
+
 	if len(connections) > 0 || isMultiSource {
+		msg := fmt.Sprintf("Connection exists for Source \"%s\", Connection \"%s\", and CLI path \"%s\"", sources[0].Name, connectionFilterString, cliPath)
+		l.Debug(msg)
+
 		return connections, nil
 	}
+
+	msg := fmt.Sprintf("No connection found. Creating a connection for Source \"%s\", Connection \"%s\", and CLI path \"%s\"", sources[0].Name, connectionFilterString, cliPath)
+	l.Debug(msg)
 
 	connectionDetails := struct {
 		Label string `survey:"label"`
 		Path  string `survey:"path"`
 	}{}
 
-	if len(cliPath) != 0 {
-		connectionDetails.Path = cliPath
-		connectionDetails.Label = "CLI"
+	if len(connectionFilterString) == 0 {
+		connectionDetails.Label = "cli"
 	} else {
-		var qs = []*survey.Question{
-			{
-				Name:   "path",
-				Prompt: &survey.Input{Message: "What path should the events be forwarded to (ie: /webhooks)?"},
-				Validate: func(val interface{}) error {
-					str, ok := val.(string)
-					isPath, err := isPath(str)
-					if !ok || !isPath || err != nil {
-						return errors.New("invalid path")
-					}
-					return nil
-				},
-			},
-			{
-				Name:     "label",
-				Prompt:   &survey.Input{Message: "What's your connection label (ie: My API)?"},
-				Validate: survey.Required,
-			},
-		}
+		connectionDetails.Label = connectionFilterString
+	}
 
-		err := survey.Ask(qs, &connectionDetails)
-		if err != nil {
-			fmt.Println(err.Error())
-			return connections, err
-		}
+	if len(cliPath) == 0 {
+		connectionDetails.Path = "/"
+	} else {
+		connectionDetails.Path = cliPath
 	}
 
 	alias := slug.Make(connectionDetails.Label)

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -79,7 +79,7 @@ func Listen(URL *url.URL, sourceQuery string, connectionFilterString string, fla
 		return err
 	}
 
-	// If the "clii-path" flag has been passed and the destination has a current cli path value but it's different, update destination path
+	// If the "cli-path" flag has been passed and the destination has a current cli path value but it's different, update destination path
 	if len(flags.CliPath) != 0 &&
 		len(connections) == 1 &&
 		*connections[0].Destination.CliPath != "" &&

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -79,6 +79,13 @@ func Listen(URL *url.URL, sourceQuery string, connectionFilterString string, fla
 		return err
 	}
 
+	if len(flags.CliPath) != 0 && len(connections) > 1 {
+		return errors.New(fmt.Errorf(`Multiple CLI destinations found. Cannot set the CLI path on multiple destinations.
+Specify a single destination to update the CLI path. For example, pass a connection name:
+			
+  hookdeck listen %s %s %s --cli-path %s`, URL.String(), sourceQuery, "connection-name", flags.CliPath).Error())
+	}
+
 	// If the "cli-path" flag has been passed and the destination has a current cli path value but it's different, update destination path
 	if len(flags.CliPath) != 0 &&
 		len(connections) == 1 &&

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -31,7 +31,8 @@ import (
 )
 
 type Flags struct {
-	NoWSS bool
+	NoWSS   bool
+	CliPath string
 }
 
 // listenCmd represents the listen command
@@ -45,6 +46,17 @@ func Listen(URL *url.URL, sourceQuery string, connectionFilterString string, fla
 	}
 
 	isMultiSource := len(sourceAliases) > 1 || (len(sourceAliases) == 1 && sourceAliases[0] == "*")
+
+	if flags.CliPath != "" {
+		if isMultiSource {
+			return errors.New("Can only set a CLI path when listening to a single source")
+		}
+
+		_, err = isPath(flags.CliPath)
+		if err != nil {
+			return errors.New("The CLI path must be in a valid format")
+		}
+	}
 
 	if config.Profile.APIKey == "" {
 		guestURL, err = login.GuestLogin(config)
@@ -62,9 +74,31 @@ func Listen(URL *url.URL, sourceQuery string, connectionFilterString string, fla
 		return err
 	}
 
-	connections, err := getConnections(sdkClient, sources, connectionFilterString, isMultiSource)
+	connections, err := getConnections(sdkClient, sources, connectionFilterString, isMultiSource, flags.CliPath)
 	if err != nil {
 		return err
+	}
+
+	// If the "clii-path" flag has been passed and the destination has a current cli path value but it's different, update destination path
+	if len(flags.CliPath) != 0 &&
+		len(connections) == 1 &&
+		*connections[0].Destination.CliPath != "" &&
+		*connections[0].Destination.CliPath != flags.CliPath {
+
+		l := log.StandardLogger()
+		updateMsg := fmt.Sprintf("Updating destination CLI path from \"%s\" to \"%s\"", *connections[0].Destination.CliPath, flags.CliPath)
+		l.Debug(updateMsg)
+
+		path := flags.CliPath
+		_, err := sdkClient.Destination.Update(context.Background(), connections[0].Destination.Id, &hookdecksdk.DestinationUpdateRequest{
+			CliPath: hookdecksdk.Optional[string](path),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		connections[0].Destination.CliPath = &path
 	}
 
 	sources = getRelevantSources(sources, connections)


### PR DESCRIPTION
The interactive prompts for the connection label/name and the CLI path are confusing unless you already understand what the Hookdeck mental model of Source -> Connection -> Destination. Why force this mental model upon developers? Instead, use some sensible defaults and allow the connection name and CLI path to be optionally passed for use when developers need or want to understand the mental model.

## New defaults

- Connection name: `cli` (Note: The SDK doesn't allow `->` in the name or I'd have used `{source} -> {destination}`). We could instead use `{source}-to-{destination}`
- CLI path `/`, which also means that the default functionality matches that of ngrok 

The quickstart command will now be the following and will require no interaction within the terminal:

```sh
hookdeck listen {port} {source_name}
```

We could have a default for the Source name. However, I don't know what this would be, and thinking about where the event is coming from is a reasonable step towards the Hookdeck mental model.

## Behavior

For **Old = New behavior**, ✅ indicates the behavior has not changed. ⚠️ indicates a change in behavior.

| Command | Connection Exists? | Old = New behavior | Old | New |
|----------|----------|------|-----|----------|
| `hookdeck listen {port}`  | No | ⚠️ | Prompts for source, connection, and path. Creates new connection with user provided details. | Prompts for source. Creates new connection with default Connection and Destination details. |
| `hookdeck listen {port} {source}`  | No | ⚠️ | Prompts for path and connection. Creates new connection with user provided details.  | Creates new connection with default Connection and Destination details  |
| `hookdeck listen {port} {source}`  | Yes | ✅ | Runs using existing connections between `{source}` and all CLI Destinations. | Runs using existing connections between `{source}` and all CLI Destinations. |
| `hookdeck listen {port} {source} --cli-path /webhooks`  | No | N/A | N/A  | Creates new connection. Runs with `/webhooks` as path all other default details.  |
| `hookdeck listen {port} {source} --cli-path /webhooks`  | Yes | N/A | N/A  | Runs using existing connection between `{source}` and a CLI Destination. If existing Destination CLI path differs from `/webhooks` it updates the Destination. If more than one matching connection is found, asks the user to specify a connection (see **Note 1**).  |
| `hookdeck listen {port} {source} {connection}` | No | ⚠️ | Prompts for path. Creates new connection with user provided details.  | Creates new connection with `/webhooks` as path and `{connection}` as connection name.  |
| `hookdeck listen {port} {source} {connection}` | Yes | ✅ | Runs using connection that matches provided details.  | Runs using connection that matches provided details. |
| `hookdeck listen {port} {source} {connection} --cli-path /webhooks` | No | N/A | N/A | Creates new connection named `{connection}` with default Connection and Destination name but with `/webhooks` as path. |
| `hookdeck listen {port} {source} {connection} --cli-path /webhooks` | Yes | N/A | N/A  | Runs using existing connection named `{connection}` between `{source}` and a CLI Destination. If existing Destination CLI path differs from `/webhooks` it updates the Destination CLI path. If more than one matching connection is found, asks the user to specify a connection (see **Note 1**). |

### **Note 1**

DEBUG output only present due to `--log-level debug' flag.

```sh
./hookdeck-cli listen 3000 test-inbound  --cli-path /flarb --log-level debug
[Tue, 23 Jul 2024 17:29:00 BST] DEBUG Connection exists for Source "test-inbound", Connection "", and CLI path "/flarb"
Multiple CLI destinations found. Cannot set the CLI path on multiple destinations.
Specify a single destination to update the CLI path. For example, pass a connection name:

  hookdeck listen http://localhost:3000 test-inbound connection-name --cli-path /flarb
```