### PR TITLE
Fix: persist api key with login

### DIFF
--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/briandowns/spinner"
 
@@ -36,6 +37,11 @@ func Login(config *config.Config, input io.Reader) error {
 	var s *spinner.Spinner
 
 	if config.Profile.APIKey != "" {
+		log.WithFields(log.Fields{
+			"prefix": "login.Login",
+			"APIKey": config.Profile.APIKey,
+		}).Debug("Logging in with API key")
+
 		s = ansi.StartNewSpinner("Verifying credentials...", os.Stdout)
 		response, err := ValidateKey(config.APIBaseURL, config.Profile.APIKey, config.Profile.TeamID)
 		if err != nil {
@@ -44,6 +50,8 @@ func Login(config *config.Config, input io.Reader) error {
 
 		message := SuccessMessage(response.UserName, response.UserEmail, response.OrganizationName, response.TeamName, response.TeamMode == "console")
 		ansi.StopSpinner(s, message, os.Stdout)
+
+		config.Profile.SaveProfile(config.LocalConfigFile != "")
 
 		return nil
 	}


### PR DESCRIPTION
Running `hookdeck login --api-key {key}` does not save the passed API key. So, subsequently running 'hookdeck listen ...` does not have the API key context so uses whatever context it has:

- If another API key was previously saved that will be used
- If logged out, will create a completely new guest account

This fix saves the API key value to the config file so it is persisted across commands.