### PR TITLE
refactor: Config parsing & precedence

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hookdeck-cli",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Hookdeck CLI",
   "repository": {
     "type": "git",

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -38,7 +38,6 @@ func normalizeCliPathFlag(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {
 	case "cli-path":
 		name = "path"
-		break
 	}
 	return pflag.NormalizedName(name)
 }

--- a/pkg/cmd/project_use.go
+++ b/pkg/cmd/project_use.go
@@ -5,13 +5,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/hookdeck/hookdeck-cli/pkg/hookdeck"
-	"github.com/hookdeck/hookdeck-cli/pkg/validators"
 	"github.com/hookdeck/hookdeck-cli/pkg/project"
+	"github.com/hookdeck/hookdeck-cli/pkg/validators"
 )
 
 type projectUseCmd struct {
-	cmd   *cobra.Command
-	local bool
+	cmd *cobra.Command
+	// local bool
 }
 
 func newProjectUseCmd() *projectUseCmd {
@@ -23,7 +23,10 @@ func newProjectUseCmd() *projectUseCmd {
 		Short: "Select your active project for future commands",
 		RunE:  lc.runProjectUseCmd,
 	}
-	lc.cmd.Flags().BoolVar(&lc.local, "local", false, "Pin active project to the current directory")
+
+	// With the change in config management (either local or global, not both), this flag is no longer needed
+	// TODO: consider remove / deprecate
+	// lc.cmd.Flags().BoolVar(&lc.local, "local", false, "Pin active project to the current directory")
 
 	return lc
 }
@@ -74,5 +77,5 @@ func (lc *projectUseCmd) runProjectUseCmd(cmd *cobra.Command, args []string) err
 		}
 	}
 
-	return Config.UseProject(lc.local, project.Id, project.Mode)
+	return Config.UseProject(project.Id, project.Mode)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -91,7 +91,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&Config.Profile.APIKey, "cli-key", "", "(deprecated) Your API key to use for the command")
 	rootCmd.PersistentFlags().StringVar(&Config.Profile.APIKey, "api-key", "", "Your API key to use for the command")
 	rootCmd.PersistentFlags().StringVar(&Config.Color, "color", "", "turn on/off color output (on, off, auto)")
-	rootCmd.PersistentFlags().StringVar(&Config.LocalConfigFile, "config", "", "config file (default is $HOME/.config/hookdeck/config.toml)")
+	rootCmd.PersistentFlags().StringVar(&Config.ConfigFileFlag, "config", "", "config file (default is $HOME/.config/hookdeck/config.toml)")
 	rootCmd.PersistentFlags().StringVar(&Config.DeviceName, "device-name", "", "device name")
 	rootCmd.PersistentFlags().StringVar(&Config.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().BoolVar(&Config.Insecure, "insecure", false, "Allow invalid TLS certificates")

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -28,6 +28,8 @@ func newWhoamiCmd() *whoamiCmd {
 }
 
 func (lc *whoamiCmd) runWhoamiCmd(cmd *cobra.Command, args []string) error {
+	fmt.Println(Config.Profile)
+
 	if err := Config.Profile.ValidateAPIKey(); err != nil {
 		return err
 	}

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -28,8 +28,6 @@ func newWhoamiCmd() *whoamiCmd {
 }
 
 func (lc *whoamiCmd) runWhoamiCmd(cmd *cobra.Command, args []string) error {
-	fmt.Println(Config.Profile)
-
 	if err := Config.Profile.ValidateAPIKey(); err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,16 +44,15 @@ type Config struct {
 	Insecure         bool
 
 	// Config
-	GlobalConfigFile string
-	GlobalConfig     *viper.Viper
-	LocalConfigFile  string
-	LocalConfig      *viper.Viper
+	ConfigFileFlag string // flag -- should NOT use this directly
+	configFile     string // resolved path of config file
+	viper          *viper.Viper
 }
 
-// GetConfigFolder retrieves the folder where the profiles file is stored
+// getConfigFolder retrieves the folder where the profiles file is stored
 // It searches for the xdg environment path first and will secondarily
 // place it in the home directory
-func (c *Config) GetConfigFolder(xdgPath string) string {
+func getConfigFolder(xdgPath string) string {
 	configPath := xdgPath
 
 	if configPath == "" {
@@ -97,51 +96,29 @@ func (c *Config) InitConfig() {
 		TimestampFormat: time.RFC1123,
 	}
 
-	c.GlobalConfig = viper.New()
-	c.LocalConfig = viper.New()
+	c.viper = viper.New()
 
-	// Read global config
-	globalConfigFolder := c.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
-	c.GlobalConfigFile = filepath.Join(globalConfigFolder, "config.toml")
-	c.GlobalConfig.SetConfigType("toml")
-	c.GlobalConfig.SetConfigFile(c.GlobalConfigFile)
-	c.GlobalConfig.SetConfigPermissions(os.FileMode(0600))
-	// Try to change permissions manually, because we used to create files
-	// with default permissions (0644)
-	err := os.Chmod(c.GlobalConfigFile, os.FileMode(0600))
-	if err != nil && !os.IsNotExist(err) {
-		log.Fatalf("%s", err)
-	}
-	if err := c.GlobalConfig.ReadInConfig(); err == nil {
-		log.WithFields(log.Fields{
-			"prefix": "config.Config.InitConfig",
-			"path":   c.GlobalConfig.ConfigFileUsed(),
-		}).Debug("Using global profiles file")
-	}
+	configPath, isGlobalConfig := getConfigPath(c.ConfigFileFlag)
+	c.configFile = configPath
+	c.viper.SetConfigType("toml")
+	c.viper.SetConfigFile(c.configFile)
 
-	// Read local config
-	workspaceFolder, err := os.Getwd()
-	if err != nil {
-		log.Fatal(err)
-	}
-	localConfigFile := ""
-	if c.LocalConfigFile == "" {
-		localConfigFile = filepath.Join(workspaceFolder, ".hookdeck/config.toml")
-	} else {
-		if filepath.IsAbs(c.LocalConfigFile) {
-			localConfigFile = c.LocalConfigFile
-		} else {
-			localConfigFile = filepath.Join(workspaceFolder, c.LocalConfigFile)
+	if isGlobalConfig {
+		// Try to change permissions manually, because we used to create files
+		// with default permissions (0644)
+		c.viper.SetConfigPermissions(os.FileMode(0600))
+		err := os.Chmod(c.configFile, os.FileMode(0600))
+		if err != nil && !os.IsNotExist(err) {
+			log.Fatalf("%s", err)
 		}
 	}
-	c.LocalConfig.SetConfigType("toml")
-	c.LocalConfig.SetConfigFile(localConfigFile)
-	c.LocalConfigFile = localConfigFile
-	if err := c.LocalConfig.ReadInConfig(); err == nil {
+
+	// Read config file
+	if err := c.viper.ReadInConfig(); err == nil {
 		log.WithFields(log.Fields{
 			"prefix": "config.Config.InitConfig",
-			"path":   c.LocalConfig.ConfigFileUsed(),
-		}).Debug("Using local profiles file")
+			"path":   c.viper.ConfigFileUsed(),
+		}).Debug("Reading config file")
 	}
 
 	// Construct the config struct
@@ -175,7 +152,7 @@ func (c *Config) InitConfig() {
 func (c *Config) EditConfig() error {
 	var err error
 
-	fmt.Println("Opening config file:", c.LocalConfigFile)
+	fmt.Println("Opening config file:", c.configFile)
 
 	switch runtime.GOOS {
 	case "darwin", "linux":
@@ -184,7 +161,7 @@ func (c *Config) EditConfig() error {
 			editor = "vi"
 		}
 
-		cmd := exec.Command(editor, c.LocalConfigFile)
+		cmd := exec.Command(editor, c.configFile)
 		// Some editors detect whether they have control of stdin/out and will
 		// fail if they do not.
 		cmd.Stdin = os.Stdin
@@ -194,7 +171,7 @@ func (c *Config) EditConfig() error {
 	case "windows":
 		// As far as I can tell, Windows doesn't have an easily accesible or
 		// comparable option to $EDITOR, so default to notepad for now
-		err = exec.Command("notepad", c.LocalConfigFile).Run()
+		err = exec.Command("notepad", c.configFile).Run()
 	default:
 		err = fmt.Errorf("unsupported platform")
 	}
@@ -203,16 +180,16 @@ func (c *Config) EditConfig() error {
 }
 
 // UseProject selects the active project to be used
-func (c *Config) UseProject(local bool, teamId string, teamMode string) error {
+func (c *Config) UseProject(teamId string, teamMode string) error {
 	c.Profile.TeamID = teamId
 	c.Profile.TeamMode = teamMode
-	return c.Profile.SaveProfile(local)
+	return c.Profile.SaveProfile()
 }
 
 func (c *Config) ListProfiles() []string {
 	var profiles []string
 
-	for field, value := range c.GlobalConfig.AllSettings() {
+	for field, value := range c.viper.AllSettings() {
 		if isProfile(value) {
 			profiles = append(profiles, field)
 		}
@@ -222,8 +199,9 @@ func (c *Config) ListProfiles() []string {
 }
 
 // RemoveAllProfiles removes all the profiles from the config file.
+// TODO: consider adding log to clarify which config file is being used
 func (c *Config) RemoveAllProfiles() error {
-	runtimeViper := c.GlobalConfig
+	runtimeViper := c.viper
 	var err error
 
 	for field, value := range runtimeViper.AllSettings() {
@@ -241,43 +219,50 @@ func (c *Config) RemoveAllProfiles() error {
 	}
 
 	runtimeViper.SetConfigType("toml")
-	runtimeViper.SetConfigFile(c.GlobalConfig.ConfigFileUsed())
-	c.GlobalConfig = runtimeViper
-	return c.WriteGlobalConfig()
+	runtimeViper.SetConfigFile(c.viper.ConfigFileUsed())
+	c.viper = runtimeViper
+	return c.WriteConfig()
 }
 
-func (c *Config) WriteGlobalConfig() error {
-	if err := makePath(c.GlobalConfig.ConfigFileUsed()); err != nil {
+func (c *Config) WriteConfig() error {
+	if err := makePath(c.viper.ConfigFileUsed()); err != nil {
 		return err
 	}
 
 	log.WithFields(log.Fields{
-		"prefix": "config.Config.WriteGlobalConfig",
-		"path":   c.GlobalConfig.ConfigFileUsed(),
-	}).Debug("Writing global config")
+		"prefix": "config.Config.WriteConfig",
+		"path":   c.viper.WriteConfig(),
+	}).Debug("Writing config")
 
-	return c.GlobalConfig.WriteConfig()
-}
-
-func (c *Config) WriteLocalConfig() error {
-	if err := makePath(c.LocalConfig.ConfigFileUsed()); err != nil {
-		return err
-	}
-	return c.LocalConfig.WriteConfig()
+	return c.viper.WriteConfig()
 }
 
 // Construct the config struct from flags > local config > global config
 func (c *Config) constructConfig() {
-	c.Color = getStringConfig([]string{c.Color, c.LocalConfig.GetString("color"), c.GlobalConfig.GetString(("color")), "auto"})
-	c.LogLevel = getStringConfig([]string{c.LogLevel, c.LocalConfig.GetString("log"), c.GlobalConfig.GetString(("log")), "info"})
-	c.APIBaseURL = getStringConfig([]string{c.APIBaseURL, c.LocalConfig.GetString("api_base"), c.GlobalConfig.GetString(("api_base")), hookdeck.DefaultAPIBaseURL})
-	c.DashboardBaseURL = getStringConfig([]string{c.DashboardBaseURL, c.LocalConfig.GetString("dashboard_base"), c.GlobalConfig.GetString(("dashboard_base")), hookdeck.DefaultDashboardBaseURL})
-	c.ConsoleBaseURL = getStringConfig([]string{c.ConsoleBaseURL, c.LocalConfig.GetString("console_base"), c.GlobalConfig.GetString(("console_base")), hookdeck.DefaultConsoleBaseURL})
-	c.WSBaseURL = getStringConfig([]string{c.WSBaseURL, c.LocalConfig.GetString("ws_base"), c.GlobalConfig.GetString(("ws_base")), hookdeck.DefaultWebsocektURL})
-	c.Profile.Name = getStringConfig([]string{c.Profile.Name, c.LocalConfig.GetString("profile"), c.GlobalConfig.GetString(("profile")), hookdeck.DefaultProfileName})
-	c.Profile.APIKey = getStringConfig([]string{c.Profile.APIKey, c.LocalConfig.GetString("api_key"), c.GlobalConfig.GetString((c.Profile.GetConfigField("api_key"))), ""})
-	c.Profile.TeamID = getStringConfig([]string{c.Profile.TeamID, c.LocalConfig.GetString("workspace_id"), c.LocalConfig.GetString("team_id"), c.GlobalConfig.GetString((c.Profile.GetConfigField("workspace_id"))), c.GlobalConfig.GetString((c.Profile.GetConfigField("team_id"))), ""})
-	c.Profile.TeamMode = getStringConfig([]string{c.Profile.TeamMode, c.LocalConfig.GetString("workspace_mode"), c.LocalConfig.GetString("team_mode"), c.GlobalConfig.GetString((c.Profile.GetConfigField("workspace_mode"))), c.GlobalConfig.GetString((c.Profile.GetConfigField("team_mode"))), ""})
+	c.Color = getStringConfig([]string{c.Color, c.viper.GetString(("color")), "auto"})
+	c.LogLevel = getStringConfig([]string{c.LogLevel, c.viper.GetString(("log")), "info"})
+	c.APIBaseURL = getStringConfig([]string{c.APIBaseURL, c.viper.GetString(("api_base")), hookdeck.DefaultAPIBaseURL})
+	c.DashboardBaseURL = getStringConfig([]string{c.DashboardBaseURL, c.viper.GetString(("dashboard_base")), hookdeck.DefaultDashboardBaseURL})
+	c.ConsoleBaseURL = getStringConfig([]string{c.ConsoleBaseURL, c.viper.GetString(("console_base")), hookdeck.DefaultConsoleBaseURL})
+	c.WSBaseURL = getStringConfig([]string{c.WSBaseURL, c.viper.GetString(("ws_base")), hookdeck.DefaultWebsocektURL})
+	c.Profile.Name = getStringConfig([]string{c.Profile.Name, c.viper.GetString(("profile")), hookdeck.DefaultProfileName})
+	// Needs to support both profile-based config
+	// and top-level config for backward compat. For example:
+	// ````
+	// [default]
+	//   api_key = "key"
+	// ````
+	// vs
+	// ````
+	// api_key = "key"
+	// ```
+	// Also support a few deprecated terminology
+	// "workspace" > "team"
+	// TODO: use "project" instead of "workspace"
+	// TODO: use "cli_key" instead of "api_key"
+	c.Profile.APIKey = getStringConfig([]string{c.Profile.APIKey, c.viper.GetString(c.Profile.GetConfigField("api_key")), c.viper.GetString("api_key"), ""})
+	c.Profile.APIKey = getStringConfig([]string{c.Profile.APIKey, c.viper.GetString(c.Profile.GetConfigField("workspace_id")), c.viper.GetString(c.Profile.GetConfigField("team_id")), c.viper.GetString("workspace_id"), ""})
+	c.Profile.APIKey = getStringConfig([]string{c.Profile.APIKey, c.viper.GetString(c.Profile.GetConfigField("workspace_mode")), c.viper.GetString(c.Profile.GetConfigField("team_mode")), c.viper.GetString("workspace_mode"), ""})
 }
 
 func getStringConfig(values []string) string {
@@ -288,6 +273,38 @@ func getStringConfig(values []string) string {
 	}
 
 	return values[len(values)-1]
+}
+
+// getConfigPath returns the path for the config file.
+// Precedence:
+// - path (if path is provided)
+// - `${PWD}/.hookdeck/config.toml`
+// - `${HOME}/.config/hookdeck/config.toml`
+// Returns the path string and a boolean indicating whether it's the global default path.
+func getConfigPath(path string) (string, bool) {
+	workspaceFolder, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if path != "" {
+		if filepath.IsAbs(path) {
+			return path, false
+		}
+		return filepath.Join(workspaceFolder, path), false
+	}
+
+	localConfigPath := filepath.Join(workspaceFolder, ".hookdeck/config.toml")
+	localConfigExists, err := fileExists(localConfigPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if localConfigExists {
+		return localConfigPath, false
+	}
+
+	globalConfigFolder := getConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	return filepath.Join(globalConfigFolder, "config.toml"), true
 }
 
 // isProfile identifies whether a value in the config pertains to a profile.
@@ -364,4 +381,15 @@ func deepSearch(m map[string]interface{}, path []string) map[string]interface{} 
 	}
 
 	return m
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,11 +90,12 @@ func (c *Config) InitConfig() {
 	}
 
 	// Read config file
-	if err := c.viper.ReadInConfig(); err == nil {
-		log.WithFields(log.Fields{
-			"prefix": "config.Config.InitConfig",
-			"path":   c.viper.ConfigFileUsed(),
-		}).Debug("Reading config file")
+	log.WithFields(log.Fields{
+		"prefix": "config.Config.InitConfig",
+		"path":   c.viper.ConfigFileUsed(),
+	}).Debug("Reading config file")
+	if err := c.viper.ReadInConfig(); err != nil {
+		log.Fatal(err)
 	}
 
 	// Construct the config struct
@@ -175,8 +176,8 @@ func (c *Config) writeConfig() error {
 	}
 
 	log.WithFields(log.Fields{
-		"prefix": "config.Config.WriteConfig",
-		"path":   c.viper.WriteConfig(),
+		"prefix": "config.Config.writeConfig",
+		"path":   c.viper.ConfigFileUsed(),
 	}).Debug("Writing config")
 
 	return c.viper.WriteConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -268,8 +268,8 @@ func (c *Config) constructConfig() {
 	// TODO: use "project" instead of "workspace"
 	// TODO: use "cli_key" instead of "api_key"
 	c.Profile.APIKey = getStringConfig([]string{c.Profile.APIKey, c.viper.GetString(c.Profile.GetConfigField("api_key")), c.viper.GetString("api_key"), ""})
-	c.Profile.APIKey = getStringConfig([]string{c.Profile.APIKey, c.viper.GetString(c.Profile.GetConfigField("workspace_id")), c.viper.GetString(c.Profile.GetConfigField("team_id")), c.viper.GetString("workspace_id"), ""})
-	c.Profile.APIKey = getStringConfig([]string{c.Profile.APIKey, c.viper.GetString(c.Profile.GetConfigField("workspace_mode")), c.viper.GetString(c.Profile.GetConfigField("team_mode")), c.viper.GetString("workspace_mode"), ""})
+	c.Profile.TeamID = getStringConfig([]string{c.Profile.TeamID, c.viper.GetString(c.Profile.GetConfigField("workspace_id")), c.viper.GetString(c.Profile.GetConfigField("team_id")), c.viper.GetString("workspace_id"), ""})
+	c.Profile.TeamMode = getStringConfig([]string{c.Profile.TeamMode, c.viper.GetString(c.Profile.GetConfigField("workspace_mode")), c.viper.GetString(c.Profile.GetConfigField("team_mode")), c.viper.GetString("workspace_mode"), ""})
 }
 
 func getStringConfig(values []string) string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,7 +31,7 @@ func TestGetConfigPath(t *testing.T) {
 		fs := &globalNoLocalConfigFS{}
 		c := Config{fs: fs}
 		customPathInput := ""
-		expectedPath := filepath.Join(getConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml")
+		expectedPath := filepath.Join(getSystemConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml")
 
 		path, isGlobalConfig := c.getConfigPath(customPathInput)
 		assert.True(t, isGlobalConfig)
@@ -44,7 +44,7 @@ func TestGetConfigPath(t *testing.T) {
 		fs := &noConfigFS{}
 		c := Config{fs: fs}
 		customPathInput := ""
-		expectedPath := filepath.Join(getConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml")
+		expectedPath := filepath.Join(getSystemConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml")
 
 		path, isGlobalConfig := c.getConfigPath(customPathInput)
 		assert.True(t, isGlobalConfig)
@@ -255,7 +255,7 @@ func (fs *globalNoLocalConfigFS) makePath(path string) error {
 	return nil
 }
 func (fs *globalNoLocalConfigFS) fileExists(path string) (bool, error) {
-	globalConfigFolder := getConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	globalConfigFolder := getSystemConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
 	globalPath := filepath.Join(globalConfigFolder, "config.toml")
 	if path == globalPath {
 		return true, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -106,6 +106,120 @@ func TestGetConfigPath(t *testing.T) {
 	})
 }
 
+func TestInitConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty config", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{
+			LogLevel:       "info",
+			ConfigFileFlag: "./testdata/empty.toml",
+		}
+		c.InitConfig()
+
+		assert.Equal(t, "default", c.Profile.Name)
+		assert.Equal(t, "", c.Profile.APIKey)
+		assert.Equal(t, "", c.Profile.TeamID)
+		assert.Equal(t, "", c.Profile.TeamMode)
+	})
+
+	t.Run("default profile", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{
+			LogLevel:       "info",
+			ConfigFileFlag: "./testdata/default-profile.toml",
+		}
+		c.InitConfig()
+
+		assert.Equal(t, "default", c.Profile.Name)
+		assert.Equal(t, "test_api_key", c.Profile.APIKey)
+		assert.Equal(t, "test_workspace_id", c.Profile.TeamID)
+		assert.Equal(t, "test_workspace_mode", c.Profile.TeamMode)
+	})
+
+	t.Run("multiple profile", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{
+			LogLevel:       "info",
+			ConfigFileFlag: "./testdata/multiple-profiles.toml",
+		}
+		c.InitConfig()
+
+		assert.Equal(t, "account_2", c.Profile.Name)
+		assert.Equal(t, "account_2_test_api_key", c.Profile.APIKey)
+		assert.Equal(t, "account_2_test_workspace_id", c.Profile.TeamID)
+		assert.Equal(t, "account_2_test_workspace_mode", c.Profile.TeamMode)
+	})
+
+	t.Run("custom profile", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{
+			LogLevel:       "info",
+			ConfigFileFlag: "./testdata/multiple-profiles.toml",
+		}
+		c.Profile.Name = "account_3"
+		c.InitConfig()
+
+		assert.Equal(t, "account_3", c.Profile.Name)
+		assert.Equal(t, "account_3_test_api_key", c.Profile.APIKey)
+		assert.Equal(t, "account_3_test_workspace_id", c.Profile.TeamID)
+		assert.Equal(t, "account_3_test_workspace_mode", c.Profile.TeamMode)
+	})
+
+	t.Run("local full", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{
+			LogLevel:       "info",
+			ConfigFileFlag: "./testdata/local-full.toml",
+		}
+		c.InitConfig()
+
+		assert.Equal(t, "default", c.Profile.Name)
+		assert.Equal(t, "local_api_key", c.Profile.APIKey)
+		assert.Equal(t, "local_workspace_id", c.Profile.TeamID)
+		assert.Equal(t, "local_workspace_mode", c.Profile.TeamMode)
+	})
+
+	// TODO: Consider this case. This is a breaking change.
+	// BREAKINGCHANGE
+	t.Run("local workspace only", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{
+			LogLevel:       "info",
+			ConfigFileFlag: "./testdata/local-workspace-only.toml",
+		}
+		c.InitConfig()
+
+		assert.Equal(t, "default", c.Profile.Name)
+		assert.Equal(t, "", c.Profile.APIKey)
+		assert.Equal(t, "local_workspace_id", c.Profile.TeamID)
+		assert.Equal(t, "", c.Profile.TeamMode)
+	})
+
+	t.Run("api key override", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{
+			LogLevel:       "info",
+			ConfigFileFlag: "./testdata/default-profile.toml",
+		}
+		apiKey := "overridden_api_key"
+		c.Profile.APIKey = apiKey
+		c.InitConfig()
+
+		assert.Equal(t, "default", c.Profile.Name)
+		assert.Equal(t, apiKey, c.Profile.APIKey)
+		assert.Equal(t, "test_workspace_id", c.Profile.TeamID)
+		assert.Equal(t, "test_workspace_mode", c.Profile.TeamMode)
+	})
+}
+
 // ===== Mock FS =====
 
 // Mock fs where there's no config file, whether global or local

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -30,11 +30,12 @@ func TestGetConfigPath(t *testing.T) {
 
 		fs := &globalNoLocalConfigFS{}
 		c := Config{fs: fs}
-		customPath := ""
+		customPathInput := ""
+		expectedPath := filepath.Join(getConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml")
 
-		path, isGlobalConfig := c.getConfigPath(customPath)
+		path, isGlobalConfig := c.getConfigPath(customPathInput)
 		assert.True(t, isGlobalConfig)
-		assert.Equal(t, path, filepath.Join(getConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml"))
+		assert.Equal(t, expectedPath, path)
 	})
 
 	t.Run("with no local or custom config - should return global config path", func(t *testing.T) {
@@ -42,11 +43,12 @@ func TestGetConfigPath(t *testing.T) {
 
 		fs := &noConfigFS{}
 		c := Config{fs: fs}
-		customPath := ""
+		customPathInput := ""
+		expectedPath := filepath.Join(getConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml")
 
-		path, isGlobalConfig := c.getConfigPath(customPath)
+		path, isGlobalConfig := c.getConfigPath(customPathInput)
 		assert.True(t, isGlobalConfig)
-		assert.Equal(t, path, filepath.Join(getConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml"))
+		assert.Equal(t, expectedPath, path)
 	})
 
 	t.Run("with local and custom config - should return custom config path", func(t *testing.T) {
@@ -54,11 +56,12 @@ func TestGetConfigPath(t *testing.T) {
 
 		fs := &globalAndLocalConfigFS{}
 		c := Config{fs: fs}
-		customPath := "/absolute/custom/config.toml"
+		customPathInput := "/absolute/custom/config.toml"
+		expectedPath := customPathInput
 
-		path, isGlobalConfig := c.getConfigPath(customPath)
+		path, isGlobalConfig := c.getConfigPath(customPathInput)
 		assert.False(t, isGlobalConfig)
-		assert.Equal(t, path, customPath)
+		assert.Equal(t, expectedPath, path)
 	})
 
 	t.Run("with local only - should return local config path", func(t *testing.T) {
@@ -66,12 +69,13 @@ func TestGetConfigPath(t *testing.T) {
 
 		fs := &globalAndLocalConfigFS{}
 		c := Config{fs: fs}
-		customPath := ""
-
-		path, isGlobalConfig := c.getConfigPath(customPath)
-		assert.False(t, isGlobalConfig)
+		customPathInput := ""
 		pwd, _ := os.Getwd()
-		assert.Equal(t, path, filepath.Join(pwd, "./.hookdeck/config.toml"))
+		expectedPath := filepath.Join(pwd, "./.hookdeck/config.toml")
+
+		path, isGlobalConfig := c.getConfigPath(customPathInput)
+		assert.False(t, isGlobalConfig)
+		assert.Equal(t, expectedPath, path)
 	})
 
 	t.Run("with absolute custom config - should return custom config path", func(t *testing.T) {
@@ -79,11 +83,12 @@ func TestGetConfigPath(t *testing.T) {
 
 		fs := &noConfigFS{}
 		c := Config{fs: fs}
-		customPath := "/absolute/custom/config.toml"
+		customPathInput := "/absolute/custom/config.toml"
+		expectedPath := customPathInput
 
-		path, isGlobalConfig := c.getConfigPath(customPath)
+		path, isGlobalConfig := c.getConfigPath(customPathInput)
 		assert.False(t, isGlobalConfig)
-		assert.Equal(t, path, customPath)
+		assert.Equal(t, expectedPath, path)
 	})
 
 	t.Run("with relative custom config - should return custom config path", func(t *testing.T) {
@@ -91,12 +96,13 @@ func TestGetConfigPath(t *testing.T) {
 
 		fs := &noConfigFS{}
 		c := Config{fs: fs}
-		customPath := "absolute/custom/config.toml"
-
-		path, isGlobalConfig := c.getConfigPath(customPath)
-		assert.False(t, isGlobalConfig)
+		customPathInput := "absolute/custom/config.toml"
 		pwd, _ := os.Getwd()
-		assert.Equal(t, path, filepath.Join(pwd, customPath))
+		expectedPath := filepath.Join(pwd, customPathInput)
+
+		path, isGlobalConfig := c.getConfigPath(customPathInput)
+		assert.False(t, isGlobalConfig)
+		assert.Equal(t, expectedPath, path)
 	})
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,4 +20,159 @@ func TestRemoveKey(t *testing.T) {
 
 	require.EqualValues(t, []string{"stay"}, nv.AllKeys())
 	require.ElementsMatch(t, []string{"stay", "remove"}, v.AllKeys())
+}
+
+func TestGetConfigPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with no config - should return global config path", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &globalNoLocalConfigFS{}
+		c := Config{fs: fs}
+		customPath := ""
+
+		path, isGlobalConfig := c.getConfigPath(customPath)
+		assert.True(t, isGlobalConfig)
+		assert.Equal(t, path, filepath.Join(getConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml"))
+	})
+
+	t.Run("with no local or custom config - should return global config path", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &noConfigFS{}
+		c := Config{fs: fs}
+		customPath := ""
+
+		path, isGlobalConfig := c.getConfigPath(customPath)
+		assert.True(t, isGlobalConfig)
+		assert.Equal(t, path, filepath.Join(getConfigFolder(os.Getenv("XDG_CONFIG_HOME")), "config.toml"))
+	})
+
+	t.Run("with local and custom config - should return custom config path", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &globalAndLocalConfigFS{}
+		c := Config{fs: fs}
+		customPath := "/absolute/custom/config.toml"
+
+		path, isGlobalConfig := c.getConfigPath(customPath)
+		assert.False(t, isGlobalConfig)
+		assert.Equal(t, path, customPath)
+	})
+
+	t.Run("with local only - should return local config path", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &globalAndLocalConfigFS{}
+		c := Config{fs: fs}
+		customPath := ""
+
+		path, isGlobalConfig := c.getConfigPath(customPath)
+		assert.False(t, isGlobalConfig)
+		pwd, _ := os.Getwd()
+		assert.Equal(t, path, filepath.Join(pwd, "./.hookdeck/config.toml"))
+	})
+
+	t.Run("with absolute custom config - should return custom config path", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &noConfigFS{}
+		c := Config{fs: fs}
+		customPath := "/absolute/custom/config.toml"
+
+		path, isGlobalConfig := c.getConfigPath(customPath)
+		assert.False(t, isGlobalConfig)
+		assert.Equal(t, path, customPath)
+	})
+
+	t.Run("with relative custom config - should return custom config path", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &noConfigFS{}
+		c := Config{fs: fs}
+		customPath := "absolute/custom/config.toml"
+
+		path, isGlobalConfig := c.getConfigPath(customPath)
+		assert.False(t, isGlobalConfig)
+		pwd, _ := os.Getwd()
+		assert.Equal(t, path, filepath.Join(pwd, customPath))
+	})
+}
+
+// ===== Mock FS =====
+
+// Mock fs where there's no config file, whether global or local
+type noConfigFS struct{}
+
+var _ ConfigFS = &noConfigFS{}
+
+func (fs *noConfigFS) makePath(path string) error {
+	return nil
+}
+func (fs *noConfigFS) fileExists(path string) (bool, error) {
+	return false, nil
+}
+
+// Mock fs where there's global and local config file
+type globalAndLocalConfigFS struct{}
+
+var _ ConfigFS = &globalAndLocalConfigFS{}
+
+func (fs *globalAndLocalConfigFS) makePath(path string) error {
+	return nil
+}
+func (fs *globalAndLocalConfigFS) fileExists(path string) (bool, error) {
+	return true, nil
+}
+
+// Mock fs where there's global but no local config file
+type globalNoLocalConfigFS struct{}
+
+var _ ConfigFS = &globalNoLocalConfigFS{}
+
+func (fs *globalNoLocalConfigFS) makePath(path string) error {
+	return nil
+}
+func (fs *globalNoLocalConfigFS) fileExists(path string) (bool, error) {
+	globalConfigFolder := getConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	globalPath := filepath.Join(globalConfigFolder, "config.toml")
+	if path == globalPath {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Mock fs where there's no global and yes local config file
+type noGlobalYesLocalConfigFS struct{}
+
+var _ ConfigFS = &noGlobalYesLocalConfigFS{}
+
+func (fs *noGlobalYesLocalConfigFS) makePath(path string) error {
+	return nil
+}
+func (fs *noGlobalYesLocalConfigFS) fileExists(path string) (bool, error) {
+	workspaceFolder, _ := os.Getwd()
+	localPath := filepath.Join(workspaceFolder, ".hookdeck/config.toml")
+	if path == localPath {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Mock fs where there's only custom local config at ${PWD}/customconfig.toml
+type onlyCustomConfigFS struct{}
+
+var _ ConfigFS = &onlyCustomConfigFS{}
+
+func (fs *onlyCustomConfigFS) makePath(path string) error {
+	return nil
+}
+func (fs *onlyCustomConfigFS) fileExists(path string) (bool, error) {
+	workspaceFolder, _ := os.Getwd()
+	customConfigPath := filepath.Join(workspaceFolder, "customconfig.toml")
+	if path == customConfigPath {
+		return true, nil
+	}
+	return false, nil
 }

--- a/pkg/config/fs.go
+++ b/pkg/config/fs.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type ConfigFS interface {
+	fileExists(path string) (bool, error)
+	makePath(path string) error
+}
+
+type configFS struct{}
+
+var _ ConfigFS = &configFS{}
+
+func newConfigFS() *configFS {
+	return &configFS{}
+}
+
+func (fs *configFS) fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (fs *configFS) makePath(path string) error {
+	dir := filepath.Dir(path)
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		err = os.MkdirAll(dir, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// getSystemConfigFolder retrieves the folder where the profiles file is stored
+// It searches for the xdg environment path first and will secondarily
+// place it in the home directory
+func getSystemConfigFolder(xdgPath string) string {
+	configPath := xdgPath
+
+	if configPath == "" {
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		configPath = filepath.Join(home, ".config")
+	}
+
+	log.WithFields(log.Fields{
+		"prefix": "config.Config.GetProfilesFolder",
+		"path":   configPath,
+	}).Debug("Using profiles folder")
+
+	return filepath.Join(configPath, "hookdeck")
+}
+
+// isProfile identifies whether a value in the config pertains to a profile.
+func isProfile(value interface{}) bool {
+	// TODO: ianjabour - ideally find a better way to identify projects in config
+	_, ok := value.(map[string]interface{})
+	return ok
+}
+
+// Temporary workaround until https://github.com/spf13/viper/pull/519 can remove a key from viper
+func removeKey(v *viper.Viper, key string) (*viper.Viper, error) {
+	configMap := v.AllSettings()
+	path := strings.Split(key, ".")
+	lastKey := strings.ToLower(path[len(path)-1])
+	deepestMap := deepSearch(configMap, path[0:len(path)-1])
+	delete(deepestMap, lastKey)
+
+	buf := new(bytes.Buffer)
+
+	encodeErr := toml.NewEncoder(buf).Encode(configMap)
+	if encodeErr != nil {
+		return nil, encodeErr
+	}
+
+	nv := viper.New()
+	nv.SetConfigType("toml") // hint to viper that we've encoded the data as toml
+
+	err := nv.ReadConfig(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return nv, nil
+}
+
+// taken from https://github.com/spf13/viper/blob/master/util.go#L199,
+// we need this to delete configs, remove when viper supprts unset natively
+func deepSearch(m map[string]interface{}, path []string) map[string]interface{} {
+	for _, k := range path {
+		m2, ok := m[k]
+		if !ok {
+			// intermediate key does not exist
+			// => create it and continue from there
+			m3 := make(map[string]interface{})
+			m[k] = m3
+			m = m3
+
+			continue
+		}
+
+		m3, ok := m2.(map[string]interface{})
+		if !ok {
+			// intermediate key is a value
+			// => replace with a new map
+			m3 = make(map[string]interface{})
+			m[k] = m3
+		}
+
+		// continue search from here
+		m = m3
+	}
+
+	return m
+}
+
+// stringCoalesce returns the first non-empty string in the list of strings.
+func stringCoalesce(values ...string) string {
+	for _, str := range values {
+		if str != "" {
+			return str
+		}
+	}
+
+	return values[len(values)-1]
+}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -11,16 +11,16 @@ type Profile struct {
 	Config *Config
 }
 
-// GetConfigField returns the configuration field for the specific profile
-func (p *Profile) GetConfigField(field string) string {
+// getConfigField returns the configuration field for the specific profile
+func (p *Profile) getConfigField(field string) string {
 	return p.Name + "." + field
 }
 
 func (p *Profile) SaveProfile() error {
-	p.Config.viper.Set(p.GetConfigField("api_key"), p.APIKey)
-	p.Config.viper.Set(p.GetConfigField("workspace_id"), p.TeamID)
-	p.Config.viper.Set(p.GetConfigField("workspace_mode"), p.TeamMode)
-	return p.Config.WriteConfig()
+	p.Config.viper.Set(p.getConfigField("api_key"), p.APIKey)
+	p.Config.viper.Set(p.getConfigField("workspace_id"), p.TeamID)
+	p.Config.viper.Set(p.getConfigField("workspace_mode"), p.TeamMode)
+	return p.Config.writeConfig()
 }
 
 func (p *Profile) RemoveProfile() error {
@@ -39,12 +39,12 @@ func (p *Profile) RemoveProfile() error {
 	runtimeViper.SetConfigType("toml")
 	runtimeViper.SetConfigFile(p.Config.viper.ConfigFileUsed())
 	p.Config.viper = runtimeViper
-	return p.Config.WriteConfig()
+	return p.Config.writeConfig()
 }
 
 func (p *Profile) UseProfile() error {
 	p.Config.viper.Set("profile", p.Name)
-	return p.Config.WriteConfig()
+	return p.Config.writeConfig()
 }
 
 func (p *Profile) ValidateAPIKey() error {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -1,6 +1,8 @@
 package config
 
-import "github.com/hookdeck/hookdeck-cli/pkg/validators"
+import (
+	"github.com/hookdeck/hookdeck-cli/pkg/validators"
+)
 
 type Profile struct {
 	Name     string // profile name

--- a/pkg/config/testdata/README.md
+++ b/pkg/config/testdata/README.md
@@ -1,0 +1,8 @@
+# Config testdata
+
+Some explanation of different config testdata scenarios:
+
+- default-profile.toml: This config has a singular profile named "default".
+- empty.toml: This config is completely empty.
+- local-full.toml: This config is for local config `${PWD}/.hookdeck/config.toml` where the user has a full profile.
+- local-workspace-only.toml: This config is for local config `${PWD}/.hookdeck/config.toml` where the user only has a `workspace_id` config. This happens when user runs `$ hookdeck project use --local` to scope the usage of the project within their local scope.

--- a/pkg/config/testdata/default-profile.toml
+++ b/pkg/config/testdata/default-profile.toml
@@ -1,0 +1,6 @@
+profile = "default"
+
+[default]
+  api_key = "test_api_key"
+  workspace_id = "test_workspace_id"
+  workspace_mode = "test_workspace_mode"

--- a/pkg/config/testdata/local-full.toml
+++ b/pkg/config/testdata/local-full.toml
@@ -1,0 +1,3 @@
+api_key = "local_api_key"
+workspace_id = "local_workspace_id"
+workspace_mode = "local_workspace_mode"

--- a/pkg/config/testdata/local-workspace-only.toml
+++ b/pkg/config/testdata/local-workspace-only.toml
@@ -1,0 +1,1 @@
+workspace_id = "local_workspace_id"

--- a/pkg/config/testdata/multiple-profiles.toml
+++ b/pkg/config/testdata/multiple-profiles.toml
@@ -1,0 +1,21 @@
+profile = "account_2"
+
+[default]
+  api_key = "test_api_key"
+  workspace_id = "test_workspace_id"
+  workspace_mode = "test_workspace_mode"
+
+[account_1]
+  api_key = "account_1_test_api_key"
+  workspace_id = "account_1_test_workspace_id"
+  workspace_mode = "account_1_test_workspace_mode"
+
+[account_2]
+  api_key = "account_2_test_api_key"
+  workspace_id = "account_2_test_workspace_id"
+  workspace_mode = "account_2_test_workspace_mode"
+
+[account_3]
+  api_key = "account_3_test_api_key"
+  workspace_id = "account_3_test_workspace_id"
+  workspace_mode = "account_3_test_workspace_mode"

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -51,7 +51,7 @@ func Login(config *config.Config, input io.Reader) error {
 		message := SuccessMessage(response.UserName, response.UserEmail, response.OrganizationName, response.TeamName, response.TeamMode == "console")
 		ansi.StopSpinner(s, message, os.Stdout)
 
-		if err = config.Profile.SaveProfile(false); err != nil {
+		if err = config.Profile.SaveProfile(); err != nil {
 			return err
 		}
 		if err = config.Profile.UseProfile(); err != nil {
@@ -99,7 +99,7 @@ func Login(config *config.Config, input io.Reader) error {
 	config.Profile.TeamID = response.TeamID
 	config.Profile.TeamMode = response.TeamMode
 
-	if err = config.Profile.SaveProfile(false); err != nil {
+	if err = config.Profile.SaveProfile(); err != nil {
 		return err
 	}
 	if err = config.Profile.UseProfile(); err != nil {
@@ -145,7 +145,7 @@ func GuestLogin(config *config.Config) (string, error) {
 	config.Profile.TeamID = response.TeamID
 	config.Profile.TeamMode = response.TeamMode
 
-	if err = config.Profile.SaveProfile(false); err != nil {
+	if err = config.Profile.SaveProfile(); err != nil {
 		return "", err
 	}
 	if err = config.Profile.UseProfile(); err != nil {
@@ -185,7 +185,7 @@ func CILogin(config *config.Config, apiKey string, name string) error {
 	config.Profile.TeamID = response.TeamID
 	config.Profile.TeamMode = response.TeamMode
 
-	if err = config.Profile.SaveProfile(false); err != nil {
+	if err = config.Profile.SaveProfile(); err != nil {
 		return err
 	}
 	if err = config.Profile.UseProfile(); err != nil {

--- a/pkg/login/interactive_login.go
+++ b/pkg/login/interactive_login.go
@@ -66,7 +66,7 @@ func InteractiveLogin(config *config.Config) error {
 	config.Profile.TeamMode = response.TeamMode
 	config.Profile.TeamID = response.TeamID
 
-	if err = config.Profile.SaveProfile(false); err != nil {
+	if err = config.Profile.SaveProfile(); err != nil {
 		ansi.StopSpinner(s, "", os.Stdout)
 		return err
 	}


### PR DESCRIPTION
This is a fairly impactful PR as it involves a breaking change as well as a lot of code changes related to `pkg/config` which impacts every command. Some key pointers:

## Global & local config

Previously, we maintain 2 config scope: global & local config. Local config can be empty. This is the precedence for config values:

- accept value from flag
- read from local
- read from global

Because of this, we can also save things in the local config to override the global config. For example, `$ hookdeck project use --local` will store `workspace_id` value in the local config so that future commands in this scope will use the selected project. In this case, the local config file could be as short as:

```toml
workspace_id = "tm_123"
```

### Changes

This PR removes the concept of global & local config. There's only 1 singular config. If there's a config within the local scope (`$PWD/.hookdeck/config.toml`) or if the user provides the `--config /path/to/config.toml` flag, then the CLI will use this config file only and ignore the global config file should one exist.

## Test & refactor

Besides code to make the changes in the section above, I also refactored `pkg/config` with 2 main concerns:

1. Make the code more testable (for example, using `ConfigFS` interface to mock different filesystem scenarios)
2. Reduce public API for the package to the minimum

With that, I also added quite a bit of tests to ensure things behave correctly. Some main shoutouts:

- `TestGetConfigPath` will test that the CLI will choose the correct config file from different user input / filesystem scenarios (whether config flag is passed, whether a local config exists, etc)
- `TestInitConfig` will test what the final config looks like with different config files. You can see different scenarios in `pkg/config/testdata`. There's a README that gives some explanation for each scenario. Please feel free to add more if there's anything you'd like to test.

- [ ] Add more config scenarios. Something I haven't considered: backward compatibility.
- [ ] Should we consider adding config versioning moving forward?
- [ ] The tests currently place a very strong emphasis on profile. There's no test for other config cases like LogLevel, Base URLs, etc. Is there anything you'd like to test more? Feel free to add your own if you'd like, or comment here.