### PR TITLE
fix: use .tar.gz for all distributables

### DIFF
--- a/.goreleaser/windows.yml
+++ b/.goreleaser/windows.yml
@@ -22,10 +22,7 @@ builds:
       - amd64
       - 386
 archives:
-  - format_overrides:
-      - goos: windows
-        format: zip
-    files:
+  - files:
       - none*
 changelog:
   sort: asc


### PR DESCRIPTION
Fixes https://github.com/hookdeck/hookdeck-cli/issues/143

**Root cause**: The npm package `goBinary.url` template expects `.tar.gz` files for all platforms, but Windows releases were packaged as `.zip` files, causing the download to fail with a 404 error.

Note that `go-npm-next` has always used `untar`.

### Solution
Changed Windows archive format from `.zip` to `.tar.gz` by removing the `format_overrides` section in `.goreleaser/windows.yml`. This creates consistency across all platforms and aligns with the npm package expectations.

### Benefits
- ✅ **Fixes npm installation on Windows** - URLs now resolve correctly
- ✅ **Maintains Scoop compatibility** - Scoop supports `.tar.gz` format  
- ✅ **Cross-platform consistency** - All platforms now use `.tar.gz`
- ✅ **No breaking changes** - GoReleaser auto-updates Scoop manifest URLs

### Testing
- [x] Local GoReleaser build successful with `.tar.gz` archives
- [x] Scoop manifest correctly generated with new URLs
- [x] Archive format compatible with `go-npm-next` extraction

### Files Changed
- `.goreleaser/windows.yml` - Removed Windows-specific `.zip` format override
