### PR TITLE
Fix/too many open files

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -28,9 +28,10 @@ import (
 )
 
 type listenCmd struct {
-	cmd   *cobra.Command
-	noWSS bool
-	path  string
+	cmd            *cobra.Command
+	noWSS          bool
+	path           string
+	maxConnections int
 }
 
 // Map --cli-path to --path
@@ -95,6 +96,7 @@ Destination CLI path will be "/". To set the CLI path, use the "--path" flag.`,
 	lc.cmd.Flags().MarkHidden("no-wss")
 
 	lc.cmd.Flags().StringVar(&lc.path, "path", "", "Sets the path to which events are forwarded e.g., /webhooks or /api/stripe")
+	lc.cmd.Flags().IntVar(&lc.maxConnections, "max-connections", 50, "Maximum concurrent connections to local endpoint (default: 50, increase for high-volume testing)")
 
 	// --cli-path is an alias for
 	lc.cmd.Flags().SetNormalizeFunc(normalizeCliPathFlag)
@@ -162,7 +164,8 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	return listen.Listen(url, sourceQuery, connectionQuery, listen.Flags{
-		NoWSS: lc.noWSS,
-		Path:  lc.path,
+		NoWSS:          lc.noWSS,
+		Path:           lc.path,
+		MaxConnections: lc.maxConnections,
 	}, &Config)
 }

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -31,8 +31,9 @@ import (
 )
 
 type Flags struct {
-	NoWSS bool
-	Path  string
+	NoWSS          bool
+	Path           string
+	MaxConnections int
 }
 
 // listenCmd represents the listen command
@@ -139,6 +140,7 @@ Specify a single destination to update the path. For example, pass a connection 
 		URL:              URL,
 		Log:              log.StandardLogger(),
 		Insecure:         config.Insecure,
+		MaxConnections:   flags.MaxConnections,
 	}, connections)
 
 	err = p.Run(context.Background())


### PR DESCRIPTION
Users were experiencing issues with high load - errors like could not resolve localhost, timeouts, ... All pointing to connection exhaustion at the CLI level. 

This PR adds connection pooling along with some optimizations for connection reuse.