### PR TITLE
chore: temporarily disable cask distribution until code signing

### DIFF
--- a/.github/workflows/test-homebrew-build.yml
+++ b/.github/workflows/test-homebrew-build.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run installation tests
         run: ./test-scripts/test-homebrew-build.sh --install
 
+      # Upload generated Homebrew formula (cask distribution has been disabled)
       - name: Upload generated Homebrew files
         if: always()
         uses: actions/upload-artifact@v4
@@ -58,5 +59,4 @@ jobs:
           name: homebrew-files
           path: |
             dist/homebrew/Formula/hookdeck.rb
-            dist/homebrew/Casks/hookdeck.rb
           retention-days: 7

--- a/.github/workflows/test-homebrew-build.yml
+++ b/.github/workflows/test-homebrew-build.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".goreleaser/**"
-      - "scripts/completions.sh"
-      - "test-scripts/test-homebrew-build.sh"
-      - ".github/workflows/test-homebrew-build.yml"
 
   workflow_dispatch:
     inputs:

--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -64,38 +64,38 @@ brews:
       zsh_completion.install "completions/_hookdeck"
     
     caveats: |
-      ⚠️  WARNING: This formula is deprecated!
+      ❤ Thanks for installing the Hookdeck CLI!
       
-      Please migrate to the cask version for the latest updates:
-        brew uninstall hookdeck
-        brew install --cask hookdeck/hookdeck/hookdeck
-      
-      The formula distribution will be removed in approximately 3-6 months.
-      Learn more: https://goreleaser.com/blog/goreleaser-v2.10/#homebrew-casks
-
-homebrew_casks:
-  - name: hookdeck
-    ids:
-      - hookdeck
-    repository:
-      owner: hookdeck
-      name: homebrew-hookdeck
-    homepage: https://hookdeck.com
-    description: Receive events (e.g. webhooks) on your localhost with event history, replay, and team collaboration
-    # Install shell completions automatically
-    completions:
-      bash: "completions/hookdeck.bash"
-      zsh: "completions/_hookdeck"
-    
-    caveats: |-
-      Thanks for installing the Hookdeck CLI!
-      
-      ⚠️  If you see an error about a binary already existing:
-        brew uninstall hookdeck
-        brew install --cask hookdeck/hookdeck/hookdeck
-      
-      Shell completions have been installed automatically.
-      You may need to restart your shell for them to take effect.
-      
-      First time using the CLI? Run:
+      If this is your first time using the CLI, run:
         hookdeck login
+
+# TODO: Temporarily disabled until we implement code signing
+# Cask distribution causes Gatekeeper issues with unsigned binaries
+# Will re-enable once Apple Developer certificate is in place
+#
+# homebrew_casks:
+#   - name: hookdeck
+#     ids:
+#       - hookdeck
+#     repository:
+#       owner: hookdeck
+#       name: homebrew-hookdeck
+#     homepage: https://hookdeck.com
+#     description: Receive events (e.g. webhooks) on your localhost with event history, replay, and team collaboration
+#     # Install shell completions automatically
+#     completions:
+#       bash: "completions/hookdeck.bash"
+#       zsh: "completions/_hookdeck"
+#
+#     caveats: |-
+#       Thanks for installing the Hookdeck CLI!
+#
+#       ⚠️  If you see an error about a binary already existing:
+#         brew uninstall hookdeck
+#         brew install --cask hookdeck/hookdeck/hookdeck
+#
+#       Shell completions have been installed automatically.
+#       You may need to restart your shell for them to take effect.
+#
+#       First time using the CLI? Run:
+#         hookdeck login


### PR DESCRIPTION
- Comment out homebrew_casks section in .goreleaser/mac.yml
- Remove deprecation warning from formula caveats (formula is now primary)
- Update test script to focus on formula-only testing
- Remove cask-related tests and validations
- Update CI workflow to test only formula distribution
- Enforce Gatekeeper compliance testing (removed bypass flag)

All tests pass including installation validation and binary execution.
Will re-enable cask distribution once Apple Developer certificate is in place.