### PR TITLE
Disable changelog generation in goreleaser configuration

### DIFF
--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -33,11 +33,7 @@ release:
   prerelease: auto
   mode: append
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  disable: true
 checksum:
   name_template: "{{ .ProjectName }}-linux-checksums.txt"
 snapshot:

--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -32,11 +32,7 @@ release:
   prerelease: auto
   mode: append
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  disable: true
 checksum:
   name_template: "{{ .ProjectName }}-checksums.txt"
 snapshot:

--- a/.goreleaser/windows.yml
+++ b/.goreleaser/windows.yml
@@ -28,11 +28,7 @@ release:
   prerelease: auto
   mode: append
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  disable: true
 checksum:
   name_template: "{{ .ProjectName }}-windows-checksums.txt"
 snapshot:


### PR DESCRIPTION
Disable changelog generation for Linux, Mac, and Windows in the goreleaser configuration to streamline the release process.