### PR TITLE
fix: status bar duplicates and width handling

### DIFF
--- a/pkg/listen/tui/view.go
+++ b/pkg/listen/tui/view.go
@@ -190,11 +190,13 @@ func (m Model) renderStatusBar() string {
 	// If no events yet, just show quit instruction
 	selectedEvent := m.GetSelectedEvent()
 	if selectedEvent == nil {
-		return statusBarStyle.Render("[q] Quit")
+		return statusBarStyle.Width(m.width).Render("[q] Quit")
 	}
 
 	// Determine width-based verbosity
-	isNarrow := m.width < 100
+	// Threshold chosen to show full text only when it fits without wrapping
+	// Full text requires ~105 chars with some padding
+	isNarrow := m.width < 108
 	isVeryNarrow := m.width < 60
 
 	// Build event status message
@@ -213,7 +215,7 @@ func (m Model) renderStatusBar() string {
 			eventStatusMsg = fmt.Sprintf("> %s %s succeeded [%d] | [r] [o] [d] [q]",
 				checkmark, eventType, selectedEvent.Status)
 		} else {
-			eventStatusMsg = fmt.Sprintf("> %s %s succeeded with status %d | [r] Retry • [o] Open in dashboard • [d] Show data",
+			eventStatusMsg = fmt.Sprintf("> %s %s succeeded with status %d | [r] Retry • [o] Open in dashboard • [d] Show data • [q] Quit",
 				checkmark, eventType, selectedEvent.Status)
 		}
 	} else {
@@ -241,12 +243,12 @@ func (m Model) renderStatusBar() string {
 					xmark, eventType, selectedEvent.Status)
 			}
 		} else {
-			eventStatusMsg = fmt.Sprintf("> %s %s %s | [r] Retry • [o] Open in dashboard • [d] Show event data",
+			eventStatusMsg = fmt.Sprintf("> %s %s %s | [r] Retry • [o] Open in dashboard • [d] Show event data • [q] Quit",
 				xmark, eventType, statusText)
 		}
 	}
 
-	return statusBarStyle.Render(eventStatusMsg)
+	return statusBarStyle.Width(m.width).Render(eventStatusMsg)
 }
 
 // FormatEventLog formats an event into a log line matching the current style


### PR DESCRIPTION
Fixed three issues in TUI status bar:

1. Duplicate '[q] Quit' on narrow terminals:
   - Added .Width(m.width) constraint to statusBarStyle.Render() calls
   - Prevents text wrapping when terminal width is constrained
   - Status bar now truncates instead of wrapping to new line

2. Missing '[q] Quit' on wide terminals:
   - Added '• [q] Quit' to wide terminal status messages
   - Now consistently shows quit option across all terminal sizes

3. Width threshold adjustment:
   - Adjusted isNarrow threshold from 100 to 108 columns
   - Prevents wrapping when switching from compact to full-text mode
   - Full menu text only appears when there's enough space to fit
Changes in renderStatusBar() function in pkg/listen/tui/view.go