### PR TITLE
fix: Use TLS dial for HTTPS healthchecks to prevent handshake warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ hookdeck logout
 
 When forwarding events to an HTTPS URL as the first argument to `hookdeck listen` (e.g., `https://localhost:1234/webhook`), you might encounter SSL validation errors if the destination is using a self-signed certificate.
 
-For local development scenarios, you can instruct the `listen` command to bypass this SSL certificate validation by using its `--insecure` flag. You must provide the full HTTPS URL.
+For local development scenarios, you can instruct the `listen` command to bypass this SSL certificate validation by using its `--insecure` flag. You must provide the full HTTPS URL. This flag also applies to the periodic server health checks that the CLI performs.
 
 **This is dangerous and should only be used in trusted local development environments for destinations you control.**
 
@@ -402,6 +402,14 @@ Example of skipping SSL validation for an HTTPS destination:
 
 ```sh
 hookdeck listen --insecure https://<your-ssl-url-or-url:port>/ <source-alias?> <connection-query?>
+```
+
+### Disable health checks
+
+The CLI periodically checks if your local server is reachable and displays warnings if the connection fails. If these health checks cause issues in your environment, you can disable them with the `--no-healthcheck` flag:
+
+```sh
+hookdeck listen --no-healthcheck 3000 <source-alias?>
 ```
 
 ### Version

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -186,6 +186,7 @@ hookdeck project use --profile production
 [source]              # Optional positional argument for source name
 [connection]          # Optional positional argument for connection name
 --path string         # Specific path to forward to (e.g., "/webhooks")
+--no-healthcheck      # Disable periodic health checks of the local server
 --no-wss             # Force unencrypted WebSocket connection (hidden flag)
 ```
 
@@ -205,6 +206,9 @@ hookdeck listen 3000 stripe-webhooks payment-connection
 
 # Forward to specific path
 hookdeck listen --path /webhooks
+
+# Disable periodic health checks of the local server
+hookdeck listen --no-healthcheck 3000
 
 # Force unencrypted WebSocket connection (hidden flag)
 hookdeck listen --no-wss

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -32,6 +32,7 @@ import (
 type listenCmd struct {
 	cmd            *cobra.Command
 	noWSS          bool
+	noHealthcheck  bool
 	path           string
 	maxConnections int
 	output         string
@@ -155,6 +156,8 @@ Destination CLI path will be "/". To set the CLI path, use the "--path" flag.`,
 
 	lc.cmd.Flags().StringVar(&lc.output, "output", "interactive", "Output mode: interactive (full UI), compact (simple logs), quiet (errors and warnings only)")
 
+	lc.cmd.Flags().BoolVar(&lc.noHealthcheck, "no-healthcheck", false, "Disable periodic health checks of the local server")
+
 	lc.cmd.Flags().StringVar(&lc.filterBody, "filter-body", "", "Filter events by request body using Hookdeck filter syntax (JSON)")
 	lc.cmd.Flags().StringVar(&lc.filterHeaders, "filter-headers", "", "Filter events by request headers using Hookdeck filter syntax (JSON)")
 	lc.cmd.Flags().StringVar(&lc.filterQuery, "filter-query", "", "Filter events by query parameters using Hookdeck filter syntax (JSON)")
@@ -255,6 +258,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 
 	return listen.Listen(url, sourceQuery, connectionQuery, listen.Flags{
 		NoWSS:          lc.noWSS,
+		NoHealthcheck:  lc.noHealthcheck,
 		Path:           lc.path,
 		Output:         lc.output,
 		MaxConnections: lc.maxConnections,

--- a/pkg/listen/healthcheck.go
+++ b/pkg/listen/healthcheck.go
@@ -16,10 +16,11 @@ const (
 	HealthUnreachable = healthcheck.HealthUnreachable
 )
 
-// CheckServerHealth performs a TCP connection check to the target URL
+// CheckServerHealth performs a connection check to the target URL
+// For HTTPS URLs, it performs a TLS handshake with optional certificate verification skip.
 // This is a wrapper around the healthcheck package function for backward compatibility
-func CheckServerHealth(targetURL *url.URL, timeout time.Duration) HealthCheckResult {
-	return healthcheck.CheckServerHealth(targetURL, timeout)
+func CheckServerHealth(targetURL *url.URL, timeout time.Duration, insecure bool) HealthCheckResult {
+	return healthcheck.CheckServerHealth(targetURL, timeout, insecure)
 }
 
 // FormatHealthMessage creates a user-friendly health status message


### PR DESCRIPTION
## Summary

- Fixes the TLS handshake warnings reported in #198 by using proper TLS connections for HTTPS healthchecks
- The healthcheck was using raw TCP connections which caused incomplete TLS handshake warnings on servers with self-signed certificates
- Adds `--no-healthcheck` flag as an escape hatch to disable health monitoring entirely

## Changes

- **Healthcheck TLS support**: Use `tls.DialWithDialer` for HTTPS endpoints with `InsecureSkipVerify` respecting the `--insecure` flag
- **New flag**: Add `--no-healthcheck` flag to disable periodic health checks
- **Tests**: Add HTTPS healthcheck tests for certificate validation scenarios
- **Documentation**: Update README.md and REFERENCE.md

## Test plan

- [x] Unit tests pass (`go test ./pkg/...`)
- [x] Build succeeds
- [x] New `--no-healthcheck` flag appears in `hookdeck listen --help`
- [ ] Manual test with HTTPS endpoint and self-signed certificate

Fixes #198

Made with [Cursor](https://cursor.com)