### PR TITLE
fix: add checkout step to test-npm-install workflow

### DIFF
--- a/.github/workflows/test-npm-install.yml
+++ b/.github/workflows/test-npm-install.yml
@@ -99,6 +99,9 @@ jobs:
             platform: win32
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

Fixes the `test-npm-install` workflow which was failing with:
> Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.github/actions/test-npm-install'. Did you forget to run actions/checkout before running your local action?

The workflow uses a local composite action (`.github/actions/test-npm-install`) but was missing the `actions/checkout` step before invoking it.

## Changes

- Added `actions/checkout@v4` step before the local action is used

## Test plan

- [ ] Manually trigger the `test-npm-install` workflow to verify it passes

Made with [Cursor](https://cursor.com)