### PR TITLE
fix: test-npm-install use local install and shared verify script

### DIFF
--- a/.github/actions/test-npm-install/action.yml
+++ b/.github/actions/test-npm-install/action.yml
@@ -42,81 +42,31 @@ runs:
           echo "Testing with npm tag: $VERSION (no polling needed)"
         fi
 
-    - name: Install hookdeck-cli
+    - name: Install hookdeck-cli (local, no global)
       shell: bash
       run: |
         VERSION="${{ inputs.version }}"
-        echo "Installing hookdeck-cli${VERSION}..."
-        npm install -g "hookdeck-cli${VERSION}"
+        INSTALL_DIR="${RUNNER_TEMP}/hookdeck-cli-install-test"
+        mkdir -p "$INSTALL_DIR"
+        cd "$INSTALL_DIR"
+        # Explicit package.json so npm installs here (not in repo root if runner cwd leaks)
+        echo '{"name":"hookdeck-cli-install-test","version":"1.0.0","private":true}' > package.json
+        # npm install needs package@version; tags already have @ (e.g. @latest, @beta)
+        if [[ "$VERSION" == @* ]]; then
+          PKG_SPEC="hookdeck-cli${VERSION}"
+        else
+          PKG_SPEC="hookdeck-cli@${VERSION}"
+        fi
+        echo "Installing ${PKG_SPEC} into $INSTALL_DIR..."
+        npm install "$PKG_SPEC"
+        # Required by test-npm-install-verify.sh in the next step
+        echo "INSTALL_DIR=$INSTALL_DIR" >> "$GITHUB_ENV"
 
     - name: Verify installation
       shell: bash
+      env:
+        PLATFORM: ${{ inputs.platform }}
       run: |
-        echo "Checking hookdeck binary location..."
-        which hookdeck || (echo "hookdeck not in PATH" && exit 1)
-        
-        echo "Checking hookdeck version..."
-        hookdeck --version
-
-    - name: Test wrapper script
-      shell: bash
-      run: |
-        echo "Testing wrapper script execution..."
-        hookdeck --help > /dev/null
-        echo "✓ Wrapper script works"
-
-    - name: Verify package structure
-      shell: bash
-      run: |
-        HOOKDECK_PATH=$(which hookdeck)
-        HOOKDECK_DIR=$(dirname "$HOOKDECK_PATH")
-        PACKAGE_DIR=$(dirname "$HOOKDECK_DIR")
-        
-        echo "Package directory: $PACKAGE_DIR"
-        
-        echo "Checking for wrapper script..."
-        if [ -f "$PACKAGE_DIR/bin/hookdeck.js" ]; then
-          echo "✓ Wrapper script found"
-        else
-          echo "✗ Wrapper script not found"
-          exit 1
-        fi
-        
-        echo "Checking for binaries directory..."
-        if [ -d "$PACKAGE_DIR/binaries" ]; then
-          echo "✓ Binaries directory found"
-          echo "Binaries included:"
-          ls -la "$PACKAGE_DIR/binaries" || true
-        else
-          echo "✗ Binaries directory not found"
-          exit 1
-        fi
-        
-        # Check platform-specific binary
-        PLATFORM="${{ inputs.platform }}"
-        case "$PLATFORM" in
-          darwin)
-            if [ -f "$PACKAGE_DIR/binaries/darwin-amd64/hookdeck" ] || [ -f "$PACKAGE_DIR/binaries/darwin-arm64/hookdeck" ]; then
-              echo "✓ macOS binary found"
-            else
-              echo "✗ macOS binary not found"
-              exit 1
-            fi
-            ;;
-          linux)
-            if [ -f "$PACKAGE_DIR/binaries/linux-amd64/hookdeck" ]; then
-              echo "✓ Linux binary found"
-            else
-              echo "✗ Linux binary not found"
-              exit 1
-            fi
-            ;;
-          win32)
-            if [ -f "$PACKAGE_DIR/binaries/win32-amd64/hookdeck.exe" ]; then
-              echo "✓ Windows binary found"
-            else
-              echo "✗ Windows binary not found"
-              exit 1
-            fi
-            ;;
-        esac
+        # INSTALL_DIR is set by the previous step via GITHUB_ENV
+        chmod +x test-scripts/test-npm-install-verify.sh
+        ./test-scripts/test-npm-install-verify.sh

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ default_cassette.yaml
 __debug_bin
 node_modules/
 .env
+test-scripts/.install-test/

--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,21 @@ docker run --rm -it \
     http://host.docker.internal:1234
 ```
 
+### Testing the published npm package
+
+To verify that the published npm package installs correctly and has the expected layout (wrapper script and platform binaries), use the local test script. It installs into a controlled directory (no global install) and runs the same checks as the `test-npm-install` CI workflow.
+
+```sh
+# Test with @latest (default)
+./test-scripts/test-npm-install-local.sh
+
+# Test with a specific version or tag
+./test-scripts/test-npm-install-local.sh 1.7.1
+./test-scripts/test-npm-install-local.sh @beta
+```
+
+Install output is written to `test-scripts/.install-test/` (gitignored).
+
 ## Releasing
 
 This section describes the release process for the Hookdeck CLI.

--- a/test-scripts/test-npm-install-local.sh
+++ b/test-scripts/test-npm-install-local.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Local test: install hookdeck-cli into a controlled directory and verify (no global install).
+# Runs the same verification as the test-npm-install CI action.
+#
+# Usage: ./test-scripts/test-npm-install-local.sh [version]
+#   version: optional, e.g. @latest, @beta, or 1.7.1 (default: @latest)
+#
+# Installs into test-scripts/.install-test/ (gitignored). No side effects on global npm.
+
+set -e
+
+VERSION="${1:-@latest}"
+# npm install needs package@version; tags already have @ (e.g. @latest, @beta)
+if [[ "$VERSION" == @* ]]; then
+  PKG_SPEC="hookdeck-cli${VERSION}"
+else
+  PKG_SPEC="hookdeck-cli@${VERSION}"
+fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="$SCRIPT_DIR/.install-test"
+
+echo "Installing ${PKG_SPEC} into $INSTALL_DIR (local only)..."
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+# Isolate from repo: npm would otherwise use repo root's package.json
+echo '{"name":"hookdeck-cli-install-test","version":"1.0.0","private":true}' > package.json
+npm install "$PKG_SPEC"
+echo ""
+
+export INSTALL_DIR="$(pwd)"
+"$SCRIPT_DIR/test-npm-install-verify.sh"

--- a/test-scripts/test-npm-install-verify.sh
+++ b/test-scripts/test-npm-install-verify.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Verify hookdeck-cli npm package (wrapper, binaries, platform binary).
+# Single source of truth for npm install verification; run locally or from CI.
+# Uses a local install directory only (no global install).
+#
+# Usage:
+#   INSTALL_DIR=/path/to/install ./test-scripts/test-npm-install-verify.sh
+#
+#   INSTALL_DIR = directory where "npm install hookdeck-cli@<version>" was run
+#                 (must contain node_modules/hookdeck-cli)
+#
+#   PLATFORM = optional; darwin|linux|win32 (auto-detected from uname if not set)
+#
+# Running locally (from repo root):
+#   INSTALL_DIR=$(mktemp -d)
+#   (cd "$INSTALL_DIR" && echo '{"name":"verify-test","private":true}' > package.json && npm install hookdeck-cli@latest)
+#   INSTALL_DIR="$INSTALL_DIR" ./test-scripts/test-npm-install-verify.sh
+#   rm -rf "$INSTALL_DIR"
+
+set -e
+
+if [ -z "$INSTALL_DIR" ]; then
+  echo "✗ INSTALL_DIR is required (directory containing node_modules/hookdeck-cli)"
+  echo "  Example: INSTALL_DIR=/tmp/hookdeck-cli-test ./test-scripts/test-npm-install-verify.sh"
+  exit 1
+fi
+
+PACKAGE_DIR="$INSTALL_DIR/node_modules/hookdeck-cli"
+if [ ! -d "$PACKAGE_DIR" ]; then
+  echo "✗ Package not found at $PACKAGE_DIR"
+  echo "  Run 'npm install hookdeck-cli@<version>' inside INSTALL_DIR first."
+  exit 1
+fi
+
+echo "Verifying hookdeck-cli at $PACKAGE_DIR"
+echo ""
+
+echo "Checking wrapper script..."
+if [ ! -f "$PACKAGE_DIR/bin/hookdeck.js" ]; then
+  echo "✗ Wrapper script not found at $PACKAGE_DIR/bin/hookdeck.js"
+  exit 1
+fi
+echo "✓ Wrapper script found"
+echo ""
+
+echo "Running wrapper (version)..."
+node "$PACKAGE_DIR/bin/hookdeck.js" --version
+echo ""
+
+echo "Running wrapper (--help)..."
+node "$PACKAGE_DIR/bin/hookdeck.js" --help > /dev/null
+echo "✓ Wrapper script works"
+echo ""
+
+echo "Checking for binaries directory..."
+if [ ! -d "$PACKAGE_DIR/binaries" ]; then
+  echo "✗ Binaries directory not found at $PACKAGE_DIR/binaries"
+  exit 1
+fi
+echo "✓ Binaries directory found"
+ls -la "$PACKAGE_DIR/binaries"
+echo ""
+
+# Platform: use env if set (e.g. from CI matrix), else detect from uname
+if [ -n "$PLATFORM" ]; then
+  echo "Checking platform-specific binary (platform: $PLATFORM from env)..."
+else
+  case "$(uname -s)" in
+    Darwin)  PLATFORM=darwin ;;
+    Linux)   PLATFORM=linux ;;
+    MINGW*|MSYS*|CYGWIN*) PLATFORM=win32 ;;
+    *)       echo "✗ Unsupported platform: $(uname -s)" && exit 1 ;;
+  esac
+  echo "Checking platform-specific binary (platform: $PLATFORM auto-detected)..."
+fi
+
+case "$PLATFORM" in
+  darwin)
+    if [ -f "$PACKAGE_DIR/binaries/darwin-amd64/hookdeck" ] || [ -f "$PACKAGE_DIR/binaries/darwin-arm64/hookdeck" ]; then
+      echo "✓ macOS binary found"
+    else
+      echo "✗ macOS binary not found"
+      exit 1
+    fi
+    ;;
+  linux)
+    if [ -f "$PACKAGE_DIR/binaries/linux-amd64/hookdeck" ]; then
+      echo "✓ Linux binary found"
+    else
+      echo "✗ Linux binary not found"
+      exit 1
+    fi
+    ;;
+  win32)
+    if [ -f "$PACKAGE_DIR/binaries/win32-amd64/hookdeck.exe" ]; then
+      echo "✓ Windows binary found"
+    else
+      echo "✗ Windows binary not found"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "✗ Unknown PLATFORM: $PLATFORM"
+    exit 1
+    ;;
+esac
+
+echo ""
+echo "✓ All verification checks passed!"


### PR DESCRIPTION
## Summary

Fixes the `test-npm-install` workflow and adds a single verification script used by both CI and local testing.

## Changes

- **Action**: Install into `RUNNER_TEMP` (no global install), set `INSTALL_DIR` via `GITHUB_ENV`, then run `test-npm-install-verify.sh`. Fix package spec so numeric versions use `hookdeck-cli@version` (e.g. `hookdeck-cli@1.7.1`).
- **test-npm-install-verify.sh**: Single source of truth. Verifies wrapper script, binaries directory, and platform binary. Requires `INSTALL_DIR` (directory containing `node_modules/hookdeck-cli`). Documented how to run locally in script header.
- **test-npm-install-local.sh**: Local wrapper that installs into `test-scripts/.install-test/` (gitignored) then runs the verify script. No global side effects.
- **README**: Added Testing section intro and "Testing the published npm package" subsection.
- **.gitignore**: `test-scripts/.install-test/`

## How to test

After merge, run the `test-npm-install` workflow manually (Actions → test-npm-install → Run workflow) with e.g. `@latest` to confirm it passes.

Locally: `./test-scripts/test-npm-install-local.sh` or `./test-scripts/test-npm-install-local.sh @latest`

Made with [Cursor](https://cursor.com)