### PR TITLE
Fix: Windows shell issue in test-npm-install workflow

### DIFF
--- a/.github/workflows/test-npm-install.yml
+++ b/.github/workflows/test-npm-install.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Determine version to test
         id: version
+        shell: bash
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             VERSION="${{ github.event.inputs.npm_version || '@beta' }}"


### PR DESCRIPTION
## Problem

The `test-npm-install` workflow was failing on Windows with this error:

```
ParserError: Missing '(' after 'if' in if statement.
```

The "Determine version to test" step was using bash syntax (`if [ ... ]`) but PowerShell was the default shell on Windows runners.

## Solution

Added `shell: bash` to the step to explicitly use bash on all platforms.

## Testing

This can be verified by checking that the Windows job passes in the workflow run after this PR is merged.