### PR TITLE
fix(metrics): map connection_id to webhook_id for --dimensions

### DIFF
--- a/pkg/cmd/metrics.go
+++ b/pkg/cmd/metrics.go
@@ -79,7 +79,7 @@ func addMetricsCommonFlagsEx(cmd *cobra.Command, f *metricsCommonFlags, skipIssu
 	cmd.Flags().StringVar(&f.end, "end", "", "End of time range (ISO 8601 date-time, required)")
 	cmd.Flags().StringVar(&f.granularity, "granularity", "", granularityHelp)
 	cmd.Flags().StringVar(&f.measures, "measures", "", "Comma-separated list of measures to return")
-	cmd.Flags().StringVar(&f.dimensions, "dimensions", "", "Comma-separated list of dimensions")
+	cmd.Flags().StringVar(&f.dimensions, "dimensions", "", "Comma-separated dimensions to group by (e.g. connection_id, source_id, destination_id, status)")
 	cmd.Flags().StringVar(&f.sourceID, "source-id", "", "Filter by source ID")
 	cmd.Flags().StringVar(&f.destinationID, "destination-id", "", "Filter by destination ID")
 	cmd.Flags().StringVar(&f.connectionID, "connection-id", "", "Filter by connection ID")
@@ -106,6 +106,10 @@ func metricsParamsFromFlags(f *metricsCommonFlags) hookdeck.MetricsQueryParams {
 	if f.dimensions != "" {
 		for _, s := range strings.Split(f.dimensions, ",") {
 			if t := strings.TrimSpace(s); t != "" {
+				// API expects webhook_id for connection dimension; CLI accepts connection_id/connection-id for consistency.
+				if t == "connection_id" || t == "connection-id" {
+					t = "webhook_id"
+				}
 				dimensions = append(dimensions, t)
 			}
 		}


### PR DESCRIPTION
## Summary
The API expects dimension name `webhook_id` (historical); agents and users often pass `connection_id`. This caused 422 when using `--dimensions connection_id`.

## Changes
- In `metricsParamsFromFlags`, map `connection_id` and `connection-id` to `webhook_id` before appending to dimensions so `hookdeck gateway metrics events ... --dimensions connection_id` works without 422.
- Improve `--dimensions` help with example dimensions (connection_id, source_id, destination_id, status).

## Testing
- `go test ./pkg/...` passes.

Made with [Cursor](https://cursor.com)