### PR TITLE
feat(ci): echo verify output in logs when verification fails

### DIFF
--- a/.github/actions/issue-auto-implement/action.yml
+++ b/.github/actions/issue-auto-implement/action.yml
@@ -235,6 +235,11 @@ runs:
           fi
           VERIFY_FAILURE="$VERIFY_OUTPUT"
           echo "::warning::Verification failed (attempt $i of $MAX)"
+          echo "<details><summary>Verify command output</summary>"
+          echo '```'
+          printf '%s\n' "$VERIFY_OUTPUT"
+          echo '```'
+          echo "</details>"
         done
         echo "verified=false" >> $GITHUB_OUTPUT
         echo "::error::Verification failed after $MAX attempts"


### PR DESCRIPTION
When the implement–verify loop fails, the verify command output is now echoed in a `<details>` block so it appears in the Actions log (fixes visibility of `go test` or other verify failures).

Made with [Cursor](https://cursor.com)