### PR TITLE
ci(issue-auto-implement): use go test -short in verify to skip acceptance tests

### DIFF
--- a/.github/workflows/issue-auto-implement.yml
+++ b/.github/workflows/issue-auto-implement.yml
@@ -39,3 +39,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_allowed_trigger_min_permission: ${{ vars.AUTO_IMPLEMENT_ALLOWED_TRIGGER_MIN_PERMISSION }}
           github_allowed_trigger_team: ${{ vars.AUTO_IMPLEMENT_ALLOWED_TRIGGER_TEAM }}
+          # Skip acceptance tests in verify (they need HOOKDECK_CLI_TESTING_API_KEY); unit tests use -short
+          verify_commands: go test -short ./...


### PR DESCRIPTION
Pass `verify_commands: go test -short ./...` when calling the issue-auto-implement action so the verify step skips acceptance tests (which require `HOOKDECK_CLI_TESTING_API_KEY`). Fixes verification failures in the auto-implement workflow.

Made with [Cursor](https://cursor.com)