### PR TITLE
fix(issue-auto-implement): use content-safe heredoc delimiters for pr_title/pr_body

### DIFF
--- a/.github/actions/issue-auto-implement/action.yml
+++ b/.github/actions/issue-auto-implement/action.yml
@@ -234,8 +234,8 @@ runs:
           if [ "$VERIFY_EXIT" -eq 0 ]; then
             # Pass PR meta to Create PR step via outputs (files are Claude handoff only; do not re-read in next step)
             PR_DIR=".github/actions/issue-auto-implement"
-            if [ -f "$PR_DIR/.pr_title" ]; then echo "pr_title<<PR_TITLE_DELIM" >> $GITHUB_OUTPUT; cat "$PR_DIR/.pr_title" >> $GITHUB_OUTPUT; echo "PR_TITLE_DELIM" >> $GITHUB_OUTPUT; else echo "pr_title=Implement issue #${ISSUE_NUMBER}" >> $GITHUB_OUTPUT; fi
-            if [ -f "$PR_DIR/.pr_body" ]; then echo "pr_body<<PR_BODY_DELIM" >> $GITHUB_OUTPUT; cat "$PR_DIR/.pr_body" >> $GITHUB_OUTPUT; echo "PR_BODY_DELIM" >> $GITHUB_OUTPUT; else echo "pr_body=Closes #${ISSUE_NUMBER}" >> $GITHUB_OUTPUT; fi
+            if [ -f "$PR_DIR/.pr_title" ]; then echo "pr_title<<__HOOKDECK_PR_TITLE_END_8a3f2b1c9d4e__" >> $GITHUB_OUTPUT; cat "$PR_DIR/.pr_title" >> $GITHUB_OUTPUT; echo "__HOOKDECK_PR_TITLE_END_8a3f2b1c9d4e__" >> $GITHUB_OUTPUT; else echo "pr_title=Implement issue #${ISSUE_NUMBER}" >> $GITHUB_OUTPUT; fi
+            if [ -f "$PR_DIR/.pr_body" ]; then echo "pr_body<<__HOOKDECK_PR_BODY_END_8a3f2b1c9d4e__" >> $GITHUB_OUTPUT; cat "$PR_DIR/.pr_body" >> $GITHUB_OUTPUT; echo "__HOOKDECK_PR_BODY_END_8a3f2b1c9d4e__" >> $GITHUB_OUTPUT; else echo "pr_body=Closes #${ISSUE_NUMBER}" >> $GITHUB_OUTPUT; fi
             echo "verified=true" >> $GITHUB_OUTPUT
             echo "changes_pushed=$CHANGES_PUSHED" >> $GITHUB_OUTPUT
             exit 0


### PR DESCRIPTION
The run [23172194947](https://github.com/hookdeck/hookdeck-cli/actions/runs/23172194947) failed with:
- `Invalid value. Matching delimiter not found 'PR_TITLE_DELIM'`
- `Unable to process file command 'output' successfully`

**Cause:** When writing `pr_title` and `pr_body` to `GITHUB_OUTPUT` via heredoc, the delimiters `PR_TITLE_DELIM` and `PR_BODY_DELIM` can appear **inside** the file content (e.g. in a PR title or body written by Claude). That line then ends the heredoc early, so the closing delimiter is never written and the runner reports "Matching delimiter not found".

**Fix:** Use unique, content-safe delimiters that cannot appear in user-generated PR titles/bodies: `__HOOKDECK_PR_TITLE_END_8a3f2b1c9d4e__` and `__HOOKDECK_PR_BODY_END_8a3f2b1c9d4e__`.

Made with [Cursor](https://cursor.com)