### PR TITLE
fix(issue-auto-implement): timeout, failure comment, skip verify when no code changes

### DIFF
--- a/.github/actions/issue-auto-implement/README.md
+++ b/.github/actions/issue-auto-implement/README.md
@@ -73,6 +73,16 @@ No other setup is required. Optionally set `verify_commands` (default `go test .
 
 The action ensures these labels exist (creates them if missing): `{prefix}/auto-implement`, `{prefix}/needs-info`, `{prefix}/pr-created`.
 
+## Diagnosing run failures (exit code 1)
+
+When a run fails, open the job log and check the **Implement and verify (loop)** step:
+
+- **`Error: spawnSync claude ETIMEDOUT`** — The Claude Code CLI hit the timeout in `implement.ts` (default 35 minutes). The runner killed the subprocess before Claude finished. Increase the timeout in `assess/src/implement.ts` (e.g. to 35–40 min) or simplify the issue scope. The issue comment will say "verification failed" but the real cause is implement timeout.
+- **Other failure right after `npx tsx src/implement.ts`** — The implement script exited 1. Common causes: Claude Code CLI exited non-zero (error) or missing env (e.g. fetch issue failed). Check stderr for the exact error.
+- **"Verification failed (attempt 1 of N)" and eventually "Verification failed after N attempts"** — The verify command (e.g. `go test -short ./...`) failed on every attempt. Fix the failing tests or adjust `verify_commands` in the workflow.
+
+When the issue is **already implemented** and Claude correctly writes only `.comment_body` (no code changes), the loop skips verification and exits success so the run completes and a PR/comment is posted.
+
 ## Testing
 
 From the repo root, run the assess script tests:

--- a/.github/actions/issue-auto-implement/action.yml
+++ b/.github/actions/issue-auto-implement/action.yml
@@ -229,6 +229,16 @@ runs:
             CHANGES_PUSHED="true"
           else
             echo "No changes to commit (attempt $i)."
+            # When Claude wrote only .comment_body (e.g. "already implemented"), skip verify and succeed
+            if [ -f ".github/actions/issue-auto-implement/.comment_body" ]; then
+              echo "No code changes and .comment_body present; skipping verify and exiting success."
+              PR_DIR=".github/actions/issue-auto-implement"
+              if [ -f "$PR_DIR/.pr_title" ]; then echo "pr_title<<__HOOKDECK_PR_TITLE_END_8a3f2b1c9d4e__" >> $GITHUB_OUTPUT; cat "$PR_DIR/.pr_title" >> $GITHUB_OUTPUT; echo "__HOOKDECK_PR_TITLE_END_8a3f2b1c9d4e__" >> $GITHUB_OUTPUT; else echo "pr_title=Implement issue #${ISSUE_NUMBER}" >> $GITHUB_OUTPUT; fi
+              if [ -f "$PR_DIR/.pr_body" ]; then echo "pr_body<<__HOOKDECK_PR_BODY_END_8a3f2b1c9d4e__" >> $GITHUB_OUTPUT; cat "$PR_DIR/.pr_body" >> $GITHUB_OUTPUT; echo "__HOOKDECK_PR_BODY_END_8a3f2b1c9d4e__" >> $GITHUB_OUTPUT; else echo "pr_body=Closes #${ISSUE_NUMBER}" >> $GITHUB_OUTPUT; fi
+              echo "verified=true" >> $GITHUB_OUTPUT
+              echo "changes_pushed=$CHANGES_PUSHED" >> $GITHUB_OUTPUT
+              exit 0
+            fi
           fi
           VERIFY_OUTPUT=$(eval "$VERIFY_CMDS" 2>&1); VERIFY_EXIT=$?
           if [ "$VERIFY_EXIT" -eq 0 ]; then
@@ -261,7 +271,7 @@ runs:
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         MAX_RETRIES: ${{ inputs.max_implement_retries }}
       run: |
-        BODY="The auto-implement run could not complete: verification failed after ${MAX_RETRIES} attempts. See the [workflow run]($RUN_URL) for logs. You can address the failure and re-trigger by adding a comment or re-applying the label."
+        BODY="The auto-implement run could not complete. See the [workflow run]($RUN_URL) for logs. This can happen if the Claude Code CLI timed out or failed, or if verification (e.g. \`go test\`) failed after ${MAX_RETRIES} attempts. Re-trigger by adding a comment or re-applying the label."
         curl -s -X POST \
           -H "Authorization: Bearer $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github+json" \

--- a/.github/actions/issue-auto-implement/assess/src/implement.ts
+++ b/.github/actions/issue-auto-implement/assess/src/implement.ts
@@ -125,7 +125,7 @@ function runClaudeCli(prompt: string): void {
       input: prompt,
       stdio: ['pipe', 'inherit', 'inherit'],
       encoding: 'utf-8',
-      timeout: 25 * 60 * 1000, // 25 minutes
+      timeout: 35 * 60 * 1000, // 35 minutes (complex issues or "already implemented" analysis may need more than 25)
       env,
     }
   );


### PR DESCRIPTION
## Summary
Addresses run failures (e.g. `ETIMEDOUT`) and improves the "already implemented" path.

## Changes
- **Timeout:** Increase Claude Code CLI timeout from 25 to 35 minutes so complex issues or "already implemented" analysis can finish.
- **Skip verify when no code changes:** When Claude writes only `.comment_body` (e.g. "nothing to do"), skip verification and exit success so the run completes and a PR/comment is posted.
- **Failure comment:** Update the comment posted on failure to mention timeout/CLI failure, not only "verification failed after N attempts" (which was misleading when the real cause was implement timeout).
- **README:** Add "Diagnosing run failures" section (ETIMEDOUT, implement vs verify, how to interpret logs).

## Context
Root cause of the failed run (e.g. #223) was `spawnSync claude ETIMEDOUT` after 25 minutes; the posted comment incorrectly said "verification failed after 3 attempts".

Made with [Cursor](https://cursor.com)