### PR TITLE
chore(ci): disable telemetry for acceptance tests in GitHub Actions

### DIFF
--- a/.github/workflows/test-acceptance.yml
+++ b/.github/workflows/test-acceptance.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       ACCEPTANCE_SLICE: ${{ matrix.slice }}
       HOOKDECK_CLI_TESTING_API_KEY: ${{ secrets[matrix.api_key_secret] }}
+      HOOKDECK_CLI_TELEMETRY_DISABLED: "1"
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Added the environment variable HOOKDECK_CLI_TELEMETRY_DISABLED set to "1" in the acceptance test workflow configuration to prevent telemetry data collection during test runs.