### PR TITLE
fix(cli): auth recovery for stale keys and clearer 401 UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hookdeck-cli",
-  "version": "2.1.1",
+  "version": "2.1.2-beta.1",
   "description": "Hookdeck CLI",
   "repository": {
     "type": "git",

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -121,7 +121,16 @@ func Execute() {
 			}
 
 		default:
-			if gatewayMCP {
+			if hookdeck.IsUnauthorizedError(err) {
+				msg := "Authentication failed: your API key is invalid or expired.\n\n" +
+					"Sign in again: run `hookdeck login` (browser sign-in), or `hookdeck login -i` / `hookdeck --api-key <key> login`.\n\n" +
+					"MCP: use hookdeck_login with reauth: true."
+				if gatewayMCP {
+					fmt.Fprintln(os.Stderr, msg)
+				} else {
+					fmt.Println(msg)
+				}
+			} else if gatewayMCP {
 				fmt.Fprintln(os.Stderr, err)
 			} else {
 				fmt.Println(err)

--- a/pkg/config/apiclient.go
+++ b/pkg/config/apiclient.go
@@ -10,9 +10,7 @@ import (
 var apiClient *hookdeck.Client
 var apiClientOnce sync.Once
 
-// ResetAPIClient clears the cached API client singleton. The next GetAPIClient
-// call builds a fresh client from the current config (used after login updates credentials).
-func ResetAPIClient() {
+func resetAPIClient() {
 	apiClient = nil
 	apiClientOnce = sync.Once{}
 }
@@ -20,7 +18,28 @@ func ResetAPIClient() {
 // ResetAPIClientForTesting resets the global API client singleton so that
 // tests can start with a fresh instance. Must only be called from tests.
 func ResetAPIClientForTesting() {
-	ResetAPIClient()
+	resetAPIClient()
+}
+
+// RefreshCachedAPIClient copies the current config (API base, profile key and
+// project id, log/telemetry flags) onto the cached *hookdeck.Client if one
+// already exists. Use after login or other in-process profile updates so the
+// singleton matches Profile without discarding the underlying http.Client.
+// If GetAPIClient has never been called, this is a no-op (the next GetAPIClient
+// will construct from Config).
+func (c *Config) RefreshCachedAPIClient() {
+	if apiClient == nil {
+		return
+	}
+	baseURL, err := url.Parse(c.APIBaseURL)
+	if err != nil {
+		panic("Invalid API base URL: " + err.Error())
+	}
+	apiClient.BaseURL = baseURL
+	apiClient.APIKey = c.Profile.APIKey
+	apiClient.ProjectID = c.Profile.ProjectId
+	apiClient.Verbose = c.LogLevel == "debug"
+	apiClient.TelemetryDisabled = c.TelemetryDisabled
 }
 
 // GetAPIClient returns the internal API client instance

--- a/pkg/config/apiclient.go
+++ b/pkg/config/apiclient.go
@@ -10,11 +10,17 @@ import (
 var apiClient *hookdeck.Client
 var apiClientOnce sync.Once
 
+// ResetAPIClient clears the cached API client singleton. The next GetAPIClient
+// call builds a fresh client from the current config (used after login updates credentials).
+func ResetAPIClient() {
+	apiClient = nil
+	apiClientOnce = sync.Once{}
+}
+
 // ResetAPIClientForTesting resets the global API client singleton so that
 // tests can start with a fresh instance. Must only be called from tests.
 func ResetAPIClientForTesting() {
-	apiClient = nil
-	apiClientOnce = sync.Once{}
+	ResetAPIClient()
 }
 
 // GetAPIClient returns the internal API client instance

--- a/pkg/gateway/mcp/tool_login.go
+++ b/pkg/gateway/mcp/tool_login.go
@@ -164,7 +164,9 @@ func handleLogin(srv *Server) mcpsdk.ToolHandler {
 
 			cfg.SaveActiveProfileAfterLogin()
 
-			// Update the shared client so all resource tools start working.
+			// Update the server-held client (in production this is the same pointer as
+			// config.GetAPIClient(); tests inject a separate *hookdeck.Client, so we must
+			// mutate this handle — RefreshCachedAPIClient only touches the global singleton).
 			client.APIKey = response.APIKey
 			client.ProjectID = response.ProjectID
 			org, proj, err := project.ParseProjectName(response.ProjectName)

--- a/pkg/hookdeck/client.go
+++ b/pkg/hookdeck/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/hookdeck/hookdeck-cli/pkg/useragent"
@@ -126,6 +127,22 @@ func IsNotFoundError(err error) bool {
 	return errors.As(err, &apiErr) && (apiErr.StatusCode == http.StatusNotFound || apiErr.StatusCode == http.StatusGone)
 }
 
+// IsUnauthorizedError reports whether err is an HTTP 401 from the Hookdeck API
+// (invalid or rejected credentials). Non-JSON 401 bodies still become *APIError
+// with StatusCode 401; a plain error string containing "status code: 401" is
+// treated as unauthorized for wrapped failures.
+func IsUnauthorizedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnauthorized {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "status code: 401")
+}
+
 // PerformRequest sends a request to Hookdeck and returns the response.
 func (c *Client) PerformRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
 	if req.Header == nil {
@@ -208,6 +225,14 @@ func (c *Client) PerformRequest(ctx context.Context, req *http.Request) (*http.R
 				"url":    req.URL.String(),
 				"status": resp.StatusCode,
 			}).Debug("Rate limited")
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			// Invalid or expired keys are common; avoid ERROR-level noise (e.g. whoami, agents).
+			log.WithFields(log.Fields{
+				"prefix": "client.Client.PerformRequest",
+				"method": req.Method,
+				"url":    req.URL.String(),
+				"status": resp.StatusCode,
+			}).Debug("Unauthorized response")
 		} else {
 			log.WithFields(log.Fields{
 				"prefix": "client.Client.PerformRequest 2",

--- a/pkg/hookdeck/client_test.go
+++ b/pkg/hookdeck/client_test.go
@@ -2,6 +2,7 @@ package hookdeck
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +17,19 @@ import (
 func TestIsNotFoundError_410Gone(t *testing.T) {
 	require.True(t, IsNotFoundError(&APIError{StatusCode: http.StatusGone, Message: "gone"}))
 	require.False(t, IsNotFoundError(&APIError{StatusCode: http.StatusInternalServerError, Message: "err"}))
+}
+
+func TestIsUnauthorizedError(t *testing.T) {
+	require.True(t, IsUnauthorizedError(&APIError{StatusCode: http.StatusUnauthorized, Message: "Unauthorized"}))
+	require.True(t, IsUnauthorizedError(&APIError{
+		StatusCode: http.StatusUnauthorized,
+		Message:    "unexpected http status code: 401, raw response body: Unauthorized",
+	}))
+	require.True(t, IsUnauthorizedError(fmt.Errorf("wrapped: %w", &APIError{StatusCode: http.StatusUnauthorized})))
+	require.True(t, IsUnauthorizedError(fmt.Errorf("unexpected http status code: 401, raw response body: Unauthorized")))
+	require.False(t, IsUnauthorizedError(&APIError{StatusCode: http.StatusForbidden, Message: "nope"}))
+	require.False(t, IsUnauthorizedError(nil))
+	require.False(t, IsUnauthorizedError(fmt.Errorf("network down")))
 }
 
 func TestPerformRequest_ParamsEncoding_Delete(t *testing.T) {

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -33,22 +33,29 @@ func Login(config *configpkg.Config, input io.Reader) error {
 		s = ansi.StartNewSpinner("Verifying credentials...", os.Stdout)
 		response, err := config.GetAPIClient().ValidateAPIKey()
 		if err != nil {
-			return err
+			ansi.StopSpinner(s, "", os.Stdout)
+			if !hookdeck.IsUnauthorizedError(err) {
+				return err
+			}
+			// Rejected key: continue into browser login below (must clear key first
+			// or we would re-enter this branch only).
+			fmt.Fprintln(os.Stdout, "Your saved API key is no longer valid. Starting browser sign-in...")
+			config.Profile.APIKey = ""
+		} else {
+			message := SuccessMessage(response.UserName, response.UserEmail, response.OrganizationName, response.ProjectName, response.ProjectMode == "console")
+			ansi.StopSpinner(s, message, os.Stdout)
+
+			config.Profile.ApplyValidateAPIKeyResponse(response, true)
+
+			if err = config.Profile.SaveProfile(); err != nil {
+				return err
+			}
+			if err = config.Profile.UseProfile(); err != nil {
+				return err
+			}
+
+			return nil
 		}
-
-		message := SuccessMessage(response.UserName, response.UserEmail, response.OrganizationName, response.ProjectName, response.ProjectMode == "console")
-		ansi.StopSpinner(s, message, os.Stdout)
-
-		config.Profile.ApplyValidateAPIKeyResponse(response, true)
-
-		if err = config.Profile.SaveProfile(); err != nil {
-			return err
-		}
-		if err = config.Profile.UseProfile(); err != nil {
-			return err
-		}
-
-		return nil
 	}
 
 	parsedBaseURL, err := url.Parse(config.APIBaseURL)
@@ -102,6 +109,8 @@ func Login(config *configpkg.Config, input io.Reader) error {
 	if err = config.Profile.UseProfile(); err != nil {
 		return err
 	}
+
+	configpkg.ResetAPIClient()
 
 	message := SuccessMessage(response.UserName, response.UserEmail, response.OrganizationName, response.ProjectName, response.ProjectMode == "console")
 	ansi.StopSpinner(s, message, os.Stdout)

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -110,7 +110,7 @@ func Login(config *configpkg.Config, input io.Reader) error {
 		return err
 	}
 
-	configpkg.ResetAPIClient()
+	config.RefreshCachedAPIClient()
 
 	message := SuccessMessage(response.UserName, response.UserEmail, response.OrganizationName, response.ProjectName, response.ProjectMode == "console")
 	ansi.StopSpinner(s, message, os.Stdout)

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -1,0 +1,121 @@
+package login
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	configpkg "github.com/hookdeck/hookdeck-cli/pkg/config"
+	"github.com/hookdeck/hookdeck-cli/pkg/hookdeck"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogin_validateNonUnauthorizedStillFails verifies that credential
+// verification errors other than 401 are returned immediately (no browser flow).
+func TestLogin_validateNonUnauthorizedStillFails(t *testing.T) {
+	configpkg.ResetAPIClient()
+	t.Cleanup(configpkg.ResetAPIClientForTesting)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/cli-auth/validate") {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"server boom"}`))
+			return
+		}
+		t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(ts.Close)
+
+	cfg := &configpkg.Config{
+		APIBaseURL:        ts.URL,
+		DeviceName:        "test-device",
+		LogLevel:          "error",
+		TelemetryDisabled: true,
+	}
+	cfg.Profile = configpkg.Profile{
+		Name:   "default",
+		APIKey: "hk_test_123456789012",
+		Config: cfg,
+	}
+
+	err := Login(cfg, strings.NewReader("\n"))
+	require.Error(t, err)
+}
+
+// TestLogin_unauthorizedValidateStartsBrowserFlow checks that a 401 from
+// validate is followed by POST /cli-auth (browser login), then a successful poll.
+func TestLogin_unauthorizedValidateStartsBrowserFlow(t *testing.T) {
+	configpkg.ResetAPIClient()
+	t.Cleanup(configpkg.ResetAPIClientForTesting)
+
+	oldCan := canOpenBrowser
+	oldOpen := openBrowser
+	canOpenBrowser = func() bool { return false }
+	openBrowser = func(string) error { return nil }
+	t.Cleanup(func() {
+		canOpenBrowser = oldCan
+		openBrowser = oldOpen
+	})
+
+	pollHits := 0
+	var serverURL string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/cli-auth/validate"):
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("Unauthorized"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/cli-auth"):
+			pollURL := serverURL + hookdeck.APIPathPrefix + "/cli-auth/poll?key=pollkey"
+			body, err := json.Marshal(map[string]string{
+				"browser_url": "https://example.test/auth",
+				"poll_url":    pollURL,
+			})
+			require.NoError(t, err)
+			_, _ = w.Write(body)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/cli-auth/poll"):
+			pollHits++
+			resp := map[string]interface{}{
+				"claimed":           true,
+				"key":               "hk_test_newkey_abcdefghij",
+				"team_id":           "tm_1",
+				"team_mode":         "gateway",
+				"team_name":         "Proj",
+				"user_name":         "U",
+				"user_email":        "u@example.com",
+				"organization_name": "Org",
+				"organization_id":   "org_1",
+				"client_id":         "cl_1",
+			}
+			enc, err := json.Marshal(resp)
+			require.NoError(t, err)
+			_, _ = w.Write(enc)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	serverURL = ts.URL
+	t.Cleanup(ts.Close)
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`profile = "default"
+
+[default]
+api_key = "hk_test_oldkey_abcdefghij"
+`), 0o600))
+
+	cfg, err := configpkg.LoadConfigFromFile(configPath)
+	require.NoError(t, err)
+	cfg.APIBaseURL = ts.URL
+	cfg.DeviceName = "test-device"
+	cfg.LogLevel = "error"
+	cfg.TelemetryDisabled = true
+
+	err = Login(cfg, strings.NewReader("\n"))
+	require.NoError(t, err)
+	require.Equal(t, 1, pollHits, "poll should run once with immediate claimed=true")
+	require.Equal(t, "hk_test_newkey_abcdefghij", cfg.Profile.APIKey)
+}

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -17,7 +17,7 @@ import (
 // TestLogin_validateNonUnauthorizedStillFails verifies that credential
 // verification errors other than 401 are returned immediately (no browser flow).
 func TestLogin_validateNonUnauthorizedStillFails(t *testing.T) {
-	configpkg.ResetAPIClient()
+	configpkg.ResetAPIClientForTesting()
 	t.Cleanup(configpkg.ResetAPIClientForTesting)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +49,7 @@ func TestLogin_validateNonUnauthorizedStillFails(t *testing.T) {
 // TestLogin_unauthorizedValidateStartsBrowserFlow checks that a 401 from
 // validate is followed by POST /cli-auth (browser login), then a successful poll.
 func TestLogin_unauthorizedValidateStartsBrowserFlow(t *testing.T) {
-	configpkg.ResetAPIClient()
+	configpkg.ResetAPIClientForTesting()
 	t.Cleanup(configpkg.ResetAPIClientForTesting)
 
 	oldCan := canOpenBrowser

--- a/test/acceptance/README.md
+++ b/test/acceptance/README.md
@@ -11,6 +11,8 @@ These tests run automatically in CI using API keys from `hookdeck ci`. They don'
 
 **Files:** Test files with **feature build tags** (e.g. `//go:build connection`, `//go:build request`). Each automated test file has exactly one feature tag so tests can be split into parallel slices (see [Parallelisation](#parallelisation)).
 
+**Login recovery (mock API, `basic` tag):** `login_auth_acceptance_test.go` runs the real CLI with `--api-base` pointing at a local server that returns **401** on `GET .../cli-auth/validate`, then completes a fake device-auth poll — this asserts `hookdeck login` continues into browser/device flow after a stale key (no human, no real Hookdeck key). The same file includes **`TestCIFailsFastWithInvalidAPIKeyAcceptance`**, which runs `hookdeck ci --api-key` with a bogus key against the real API and expects a quick failure with the friendly **Authentication failed** message, and asserts output does **not** contain browser/device-login phrases (`Press Enter to open the browser`, `To authenticate with Hookdeck`, etc.) so CI never enters the interactive `hookdeck login` flow.
+
 ### 2. Manual Tests (Require Human Interaction)
 These tests require browser-based authentication via `hookdeck login` and must be run manually by developers.
 

--- a/test/acceptance/login_auth_acceptance_test.go
+++ b/test/acceptance/login_auth_acceptance_test.go
@@ -1,0 +1,163 @@
+//go:build basic
+
+package acceptance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hookdeck/hookdeck-cli/pkg/hookdeck"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoginAfterValidate401StartsBrowserFlowAcceptance runs the real CLI against a local
+// mock API: GET validate returns 401, then POST /cli-auth and poll complete the device flow.
+// SSH_CONNECTION avoids the "Press Enter to open the browser" branch (non-interactive).
+func TestLoginAfterValidate401StartsBrowserFlowAcceptance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping acceptance test in short mode")
+	}
+
+	projectRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+	mainGo := filepath.Join(projectRoot, "main.go")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`profile = "default"
+
+[default]
+api_key = "hk_test_stale_accept01"
+`), 0o600))
+
+	pollHits := 0
+	var serverURL string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/cli-auth/validate"):
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("Unauthorized"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/cli-auth"):
+			pollURL := serverURL + hookdeck.APIPathPrefix + "/cli-auth/poll?key=pollkey"
+			body, encErr := json.Marshal(map[string]string{
+				"browser_url": "https://example.test/auth",
+				"poll_url":    pollURL,
+			})
+			require.NoError(t, encErr)
+			_, _ = w.Write(body)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/cli-auth/poll"):
+			pollHits++
+			resp := map[string]interface{}{
+				"claimed":           true,
+				"key":               "hk_test_newkey_accept01",
+				"team_id":           "tm_accept",
+				"team_mode":         "gateway",
+				"team_name":         "AcceptProj",
+				"user_name":         "Accept",
+				"user_email":        "accept@example.com",
+				"organization_name": "AcceptOrg",
+				"organization_id":   "org_accept",
+				"client_id":         "cl_accept",
+			}
+			enc, encErr := json.Marshal(resp)
+			require.NoError(t, encErr)
+			_, _ = w.Write(enc)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	serverURL = ts.URL
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", append([]string{"run", mainGo,
+		"--api-base", ts.URL,
+		"--hookdeck-config", configPath,
+		"--log-level", "error",
+		"login",
+	})...)
+	cmd.Dir = projectRoot
+	env := appendEnvOverride(os.Environ(), "HOOKDECK_CONFIG_FILE", configPath)
+	env = appendEnvOverride(env, "SSH_CONNECTION", "acceptance-login-mock")
+	env = appendEnvOverride(env, "HOOKDECK_CLI_TELEMETRY_DISABLED", "1")
+	cmd.Env = env
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	require.NoError(t, err, "stdout=%q stderr=%q", stdout.String(), stderr.String())
+	require.Contains(t, stdout.String(), "no longer valid", "user should see stale-key message")
+	require.Equal(t, 1, pollHits, "mock should see exactly one poll after cli-auth")
+}
+
+// TestCIFailsFastWithInvalidAPIKeyAcceptance verifies hookdeck ci does not enter the
+// interactive browser login path when the project API key is invalid — it exits with
+// an error quickly (CI-safe: no stdin / device flow).
+func TestCIFailsFastWithInvalidAPIKeyAcceptance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping acceptance test in short mode")
+	}
+
+	projectRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+	mainGo := filepath.Join(projectRoot, "main.go")
+
+	// Isolated empty profile so we do not merge with a developer's global config.
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`profile = "default"
+
+[default]
+`), 0o600))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	invalidKey := "hk_test_ci_invalid_accept01" // valid shape, not a real key
+	cmd := exec.CommandContext(ctx, "go", append([]string{"run", mainGo,
+		"--hookdeck-config", configPath,
+		"--log-level", "error",
+		"ci", "--api-key", invalidKey,
+	})...)
+	cmd.Dir = projectRoot
+	env := appendEnvOverride(os.Environ(), "HOOKDECK_CONFIG_FILE", configPath)
+	env = appendEnvOverride(env, "HOOKDECK_CLI_TELEMETRY_DISABLED", "1")
+	cmd.Env = env
+
+	start := time.Now()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	require.Error(t, err, "ci with bogus API key must fail")
+	elapsed := time.Since(start)
+	require.Less(t, elapsed, 30*time.Second, "ci should fail quickly without waiting for interactive login; took %v", elapsed)
+
+	combined := stdout.String() + "\n" + stderr.String()
+	require.Contains(t, combined, "Authentication failed",
+		"expected friendly auth message; stdout=%q stderr=%q", stdout.String(), stderr.String())
+
+	// hookdeck ci uses POST /cli-auth/ci only — it must never start the interactive
+	// browser/device login flow used by hookdeck login (pkg/login/client_login.go).
+	for _, phrase := range []string{
+		"Press Enter to open the browser",
+		"To authenticate with Hookdeck, please go to:",
+		"Your saved API key is no longer valid",
+		"Starting browser sign-in",
+		"Waiting for confirmation",
+	} {
+		require.NotContains(t, combined, phrase,
+			"ci with invalid key must not trigger browser login; saw disallowed phrase %q in stdout=%q stderr=%q",
+			phrase, stdout.String(), stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary

Improves how the CLI behaves when credentials are missing, invalid, or expired: users and agents get clearer messages, `hookdeck login` can recover from a rejected stored key without a separate `logout`, and noisy log output for expected 401s is reduced.

## Changes

- **401 handling in `Execute()`**: Map API unauthorized errors to a short, actionable message (stdout for normal CLI; **stderr only** for `hookdeck gateway mcp` so JSON-RPC on stdout stays clean). Suggests `hookdeck login`, `-i`, `--api-key`, and MCP `reauth`.
- **HTTP client**: Add `hookdeck.IsUnauthorizedError`. Log **401** responses at **debug** instead of **error** so default runs are not flooded with `Unexpected response` for expected bad keys (still diagnosable with `--log-level debug`).
- **`hookdeck login`**: If `GET /cli-auth/validate` returns **401**, stop the verify spinner, print **`Your saved API key is no longer valid. Starting browser sign-in...`**, clear the in-memory key, and continue the existing browser/device flow.
- **Config**: `ResetAPIClient()` after a successful browser login so a long-lived process picks up the new key; `ResetAPIClientForTesting` delegates to it.
- **Tests**: Unit tests for `IsUnauthorizedError` and login 401→browser flow; **basic** acceptance tests (mock API for login recovery; real API for `ci` with invalid key—fast fail, no browser phrases).

## Type of change

User-facing behavior and messaging (**fix** / UX improvement; `login` recovery is a small **feature** in behavior terms). Suggested release note: patch-level unless you treat `login` recovery as minor.

## How to verify

- `hookdeck whoami` with a bad key → friendly message, no ERROR log line at default `--log-level`.
- `hookdeck login` with stale config key → message then browser/device flow.
- `hookdeck ci --api-key <invalid>` → quick failure, no interactive login copy.
- `go test ./...` and basic acceptance slice including new tests.

Made with [Cursor](https://cursor.com)