### PR TITLE
chore: promote homebrew-core as primary macOS install path

### DIFF
--- a/.github/workflows/test-homebrew-build.yml
+++ b/.github/workflows/test-homebrew-build.yml
@@ -53,5 +53,5 @@ jobs:
         with:
           name: homebrew-files
           path: |
-            dist/homebrew/Formula/hookdeck.rb
+            dist/homebrew/Formula/hookdeck-beta.rb
           retention-days: 7

--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -47,7 +47,12 @@ archives:
       - README*
       - CHANGELOG*
 brews:
-  - name: "{{ if .Prerelease }}hookdeck-beta{{ else }}hookdeck{{ end }}"
+  # Stable releases are published to homebrew-core via Homebrew's autobump
+  # (BrewTestBot opens version-bump PRs after each tagged release). The
+  # third-party tap publishes only the beta channel — homebrew-core does
+  # not accept pre-releases, so the `hookdeck-beta` formula lives here.
+  - name: hookdeck-beta
+    skip_upload: "{{ if not .Prerelease }}true{{ end }}"
     ids:
       - hookdeck
     repository:
@@ -56,21 +61,20 @@ brews:
     directory: Formula
     homepage: https://hookdeck.com
     description: Receive events (e.g. webhooks) on your localhost with event history, replay, and team collaboration
-    
+
     install: |
       bin.install "hookdeck"
-      
+
       # Install completions from pre-generated files
       bash_completion.install "completions/hookdeck.bash" => "hookdeck"
       zsh_completion.install "completions/_hookdeck"
-    
+
     caveats: |
-      ❤ Thanks for installing the Hookdeck CLI!
-      {{ if .Prerelease }}
+      ❤ Thanks for installing the Hookdeck CLI beta!
+
       ⚠️  You are using a BETA version. Report issues at:
         https://github.com/hookdeck/hookdeck-cli/issues
-      {{ end }}
-      
+
       If this is your first time using the CLI, run:
         hookdeck login
 

--- a/README.md
+++ b/README.md
@@ -75,17 +75,26 @@ npm install hookdeck-cli@beta -g
 
 ### macOS
 
-Hookdeck CLI is available on macOS via [Homebrew](https://brew.sh/):
+Hookdeck CLI is available on macOS via [Homebrew](https://brew.sh/) in [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/h/hookdeck.rb):
 
 ```sh
-brew install hookdeck/hookdeck/hookdeck
+brew install hookdeck
 ```
 
-To install a beta (pre-release) version:
+New stable versions are picked up automatically by Homebrew's autobump after each release — `brew upgrade` will pull them in.
+
+To install a beta (pre-release) version from our tap:
 
 ```sh
 brew install hookdeck/hookdeck/hookdeck-beta
 ```
+
+> [!NOTE]
+> When [`HOMEBREW_REQUIRE_TAP_TRUST`](https://docs.brew.sh/Taps) becomes the default in Homebrew 5.2.0 / 6.0.0, installing the beta formula from a third-party tap will require an explicit trust step:
+> ```sh
+> brew trust --formula hookdeck/hookdeck/hookdeck-beta
+> ```
+> The stable `hookdeck` formula lives in homebrew-core and is not affected.
 
 ### Windows
 
@@ -1218,21 +1227,40 @@ There are also some hidden flags that are mainly used for development and debugg
 
 ## Troubleshooting
 
-### Homebrew: Binary Already Exists Error
+### Homebrew: migrating from the third-party tap to homebrew-core
 
-If you previously installed Hookdeck via the Homebrew formula and are upgrading to the cask version, you may see:
+The stable `hookdeck` formula now lives in [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/h/hookdeck.rb). The third-party `hookdeck/hookdeck` tap publishes only the beta formula.
 
-```
-Warning: It seems there is already a Binary at '/opt/homebrew/bin/hookdeck'
-from formula hookdeck; skipping link.
-```
+If you installed via the tap, the move is automatic: `brew update && brew upgrade` will pull the next stable version from homebrew-core. No action needed.
 
-To resolve this, uninstall the old formula version first, then install the cask:
+If you want to switch immediately:
 
 ```sh
-brew uninstall hookdeck
-brew install --cask hookdeck/hookdeck/hookdeck
+brew update
+brew upgrade hookdeck
 ```
+
+### Homebrew: `hookdeck` and `hookdeck-beta` conflict on link
+
+Both formulae install a binary called `hookdeck`, so only one can be linked at a time. Switching between them requires `--overwrite`:
+
+```sh
+# Switch from beta to stable
+brew link --overwrite hookdeck
+
+# Switch from stable to beta
+brew link --overwrite hookdeck-beta
+```
+
+### Homebrew: beta install asks for a `brew trust` step
+
+Once [`HOMEBREW_REQUIRE_TAP_TRUST`](https://docs.brew.sh/Taps) becomes the default in Homebrew 5.2.0 / 6.0.0, installing the beta from the third-party tap requires:
+
+```sh
+brew trust --formula hookdeck/hookdeck/hookdeck-beta
+```
+
+The stable formula lives in homebrew-core and is unaffected.
 
 
 ## Developing
@@ -1433,7 +1461,7 @@ The GitHub Actions workflow will automatically:
 - Create a stable GitHub release
 - Publish to NPM with the `latest` tag
 - Update package managers:
-  - Homebrew: `hookdeck` formula
+  - Homebrew: stable formula in [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/h/hookdeck.rb) is auto-bumped by Homebrew's BrewTestBot (no action from us; runs every ~3 hours after the tag is published). The `hookdeck-beta` formula in our third-party tap is updated only on pre-release tags.
   - Scoop: `hookdeck` package
   - Docker: Updates both the version tag and `latest`
 

--- a/test-scripts/test-homebrew-build.sh
+++ b/test-scripts/test-homebrew-build.sh
@@ -170,9 +170,11 @@ run_goreleaser_build() {
 
 # Validate Homebrew formula file
 validate_formula() {
-    echo_section "Validating Formula (dist/homebrew/Formula/hookdeck.rb)"
-    
-    local formula_file="dist/homebrew/Formula/hookdeck.rb"
+    echo_section "Validating Formula (dist/homebrew/Formula/hookdeck-beta.rb)"
+
+    # Stable releases of `hookdeck` now go to homebrew-core; the third-party
+    # tap publishes only `hookdeck-beta` on pre-release tags.
+    local formula_file="dist/homebrew/Formula/hookdeck-beta.rb"
     
     if [ ! -f "$formula_file" ]; then
         echo_error "Formula file not found at $formula_file"
@@ -298,7 +300,7 @@ setup_local_tap() {
     
     # Patch formula to use local file:// URLs for testing
     echo_info "Patching formula to use local file URLs for testing..."
-    local formula_file="$LOCAL_TAP_PATH/Formula/hookdeck.rb"
+    local formula_file="$LOCAL_TAP_PATH/Formula/hookdeck-beta.rb"
     local current_dir="$(pwd)"
     
     # Replace GitHub URLs with local file:// URLs
@@ -320,8 +322,8 @@ setup_local_tap() {
 test_formula_installation() {
     echo_section "Testing Formula Installation"
     
-    local tap_name="hookdeck-test/hookdeck-test/hookdeck"
-    
+    local tap_name="hookdeck-test/hookdeck-test/hookdeck-beta"
+
     echo_info "Installing formula: brew install $tap_name"
     if brew install "$tap_name"; then
         echo_success "Formula installed successfully"

--- a/test-scripts/test-homebrew-build.sh
+++ b/test-scripts/test-homebrew-build.sh
@@ -8,7 +8,6 @@
 # It validates that:
 #   - GoReleaser snapshot build completes successfully
 #   - Homebrew formula file is generated
-#   - Formula contains deprecation warning
 #   - Formula references completion files correctly
 #   - Completion files are bundled in the tarball
 # NOTE: Cask validation is currently commented out - focusing on formula only
@@ -528,7 +527,6 @@ main() {
         echo_info "What was validated:"
         echo "  ✓ GoReleaser configuration generates correct Homebrew formula"
         echo "  ✓ Completion files are bundled in archives"
-        echo "  ✓ Formula has deprecation warnings"
         echo "  ✓ Formula has proper completion directives"
         # echo "  ✓ Cask has proper completion directives"  # Commented out - not testing cask
         


### PR DESCRIPTION
## Summary

Follow-up to the homebrew-core acceptance (merged 2026-06-04 via [Homebrew/homebrew-core#286152](https://github.com/Homebrew/homebrew-core/pull/286152)). Updates this repo to reflect homebrew-core as the canonical stable install path, with the third-party `hookdeck/homebrew-hookdeck` tap retained only for beta. Tracked in #297.

Two logical commits:

- **`chore(release): stop publishing stable hookdeck formula to third-party tap`** — `.goreleaser/mac.yml` brews block now uses a fixed `hookdeck-beta` name with `skip_upload` gated to pre-release tags. Stable releases no longer try to publish `hookdeck.rb` to the tap (the tap's stale formula files will be removed in a follow-up PR on the tap repo, replaced by `tap_migrations.json` redirecting to homebrew-core).
- **`docs(readme): promote homebrew-core as the primary macOS install path`** — README macOS section, Releasing section, and Troubleshooting all updated. The stale "Homebrew: Binary Already Exists Error" troubleshooting entry (leftover from the abandoned cask migration) is replaced with three relevant entries: tap-to-core migration, hookdeck/hookdeck-beta link conflicts, and beta tap-trust note.

## Sequencing — important

This PR **must merge before** the tap migration PR on `hookdeck/homebrew-hookdeck`. Otherwise a future stable release could re-publish `hookdeck.rb` to the tap (GoReleaser config not yet updated) and undo the migration.

Order:
1. **This PR** → merge into `main`
2. **Tap PR** (`hookdeck/homebrew-hookdeck`) → delete stale `hookdeck.rb` files + add `tap_migrations.json`
3. Existing tap users get auto-migrated to homebrew-core on next `brew update`

## Beta channel: no behavior change

- `hookdeck-beta` formula stays in the tap, published on every pre-release tag (unchanged)
- The `caveats:` block's `{{ if .Prerelease }}...{{ end }}` conditional has been removed since the formula is now always beta. The "BETA version" warning is unconditional.
- README and `--help` install guidance for beta users includes the upcoming `brew trust --formula hookdeck/hookdeck/hookdeck-beta` step that becomes mandatory in Homebrew 5.2.0 / 6.0.0 (#294 context).

## Test plan

- [x] CI: build, acceptance, test-homebrew-build, test-npm-build all pass
- [x] CI: `test-homebrew-build` validates that the GoReleaser config still produces a syntactically valid formula on a snapshot build
- [x] Manual: `goreleaser release --snapshot --skip publish --clean --config .goreleaser/mac.yml` succeeds locally — exit 0; writes `dist/homebrew/Formula/hookdeck-beta.rb` only (not `hookdeck.rb`); class `HookdeckBeta`; caveats unconditional beta.
- [x] Manual: README `[!NOTE]` callout and code-fenced trust commands are well-formed (every line starts with `>`, code fences balanced; GitHub will render as a styled note alert).
- [x] Smoke: README install references audited. Every `brew install hookdeck/hookdeck/...` is the `-beta` formula; the unqualified `brew install hookdeck` is the only stable path documented. No lingering "tap is primary" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
