### PR TITLE
fix(release): run npm publish job on Node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
+      # npm@latest now requires Node >= 22.22 (it dropped Node 20 support), and
+      # `npm publish --provenance` (OIDC) needs a recent npm, so this job runs on
+      # Node 22.x rather than 20.x.
       - name: Upgrade npm to latest version
         run: npm install -g npm@latest
 


### PR DESCRIPTION
## Problem
The `v2.3.0` release workflow **failed to publish to npm**. GoReleaser succeeded (GitHub artifacts, Homebrew, Scoop, Docker), but the `publish-npm` job failed at *"Upgrade npm to latest version"*:

```
npm error notsup Not compatible with your version of node/npm: npm@12.0.2
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

The job pins Node 20; `npm install -g npm@latest` now resolves to npm@12, which dropped Node 20 support, so the upgrade aborts before `npm publish` runs.

## Fix
Run the `publish-npm` job on **Node 22.x**. `npm publish --provenance` (OIDC trusted publishing) needs a recent npm, so bumping Node is the right fix rather than pinning npm to an older version.

## Impact
Fixes npm publishing for all future releases. Does **not** by itself re-publish `v2.3.0` to npm — that needs a separate remediation (re-tag or manual publish), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)