### PR TITLE
fix(listen): recover when the CLI session expires server-side

### DIFF
--- a/pkg/listen/proxy/proxy.go
+++ b/pkg/listen/proxy/proxy.go
@@ -50,7 +50,7 @@ type Config struct {
 	// Disable periodic health checks of the local server
 	NoHealthcheck bool
 	// Output mode: interactive, compact, quiet
-	Output string
+	Output   string
 	GuestURL string
 	// MaxConnections allows tuning the maximum concurrent connections per host.
 	// Default: 50 concurrent connections
@@ -141,6 +141,25 @@ func (p *Proxy) Run(parentCtx context.Context) error {
 		return fmt.Errorf("error while starting a new session")
 	}
 
+	// Session-recreation data sent on every websocket connect so the server
+	// can recreate the session if it has expired server-side while the CLI
+	// is still running.
+	var connectionIDs []string
+	for _, connection := range p.connections {
+		connectionIDs = append(connectionIDs, connection.ID)
+	}
+	var sessionFiltersJSON []byte
+	if p.cfg.Filters != nil {
+		var err error
+		sessionFiltersJSON, err = json.Marshal(p.cfg.Filters)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"prefix": "proxy.Proxy.Run",
+			}).Debug("Failed to serialize session filters for reconnect headers: ", err)
+			sessionFiltersJSON = nil
+		}
+	}
+
 	// Main loop to keep attempting to connect to Hookdeck once
 	// we have created a session.
 	for canConnect() {
@@ -150,9 +169,11 @@ func (p *Proxy) Run(parentCtx context.Context) error {
 			p.cfg.Key,
 			p.cfg.ProjectID,
 			&websocket.Config{
-				Log:          p.cfg.Log,
-				NoWSS:        p.cfg.NoWSS,
-				EventHandler: websocket.EventHandlerFunc(p.processAttempt),
+				Log:                p.cfg.Log,
+				NoWSS:              p.cfg.NoWSS,
+				EventHandler:       websocket.EventHandlerFunc(p.processAttempt),
+				WebhookIDs:         connectionIDs,
+				SessionFiltersJSON: sessionFiltersJSON,
 			},
 		)
 
@@ -204,6 +225,23 @@ func (p *Proxy) Run(parentCtx context.Context) error {
 			if !canConnect() {
 				p.renderer.Cleanup()
 				return fmt.Errorf("Could not connect. Terminating after %d failed attempts to establish a connection.", nAttempts)
+			}
+			// The server reported that the session no longer exists (e.g. it
+			// expired server-side). Reconnecting with the same websocket ID
+			// can never succeed, so create a fresh session before retrying.
+			if p.webSocketClient.SessionExpired() {
+				log.WithFields(log.Fields{
+					"prefix": "proxy.Proxy.Run",
+				}).Debug("Session expired server-side, creating a new session before reconnecting")
+
+				newSession, err := p.createSession(signalCtx)
+				if err != nil || newSession.Id == "" {
+					log.WithFields(log.Fields{
+						"prefix": "proxy.Proxy.Run",
+					}).Debug("Failed to create a replacement session, retrying with the existing session: ", err)
+				} else {
+					session = newSession
+				}
 			}
 		}
 

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	ws "github.com/gorilla/websocket"
@@ -41,6 +42,16 @@ type Config struct {
 	WriteWait time.Duration
 
 	EventHandler EventHandler
+
+	// WebhookIDs are the connection IDs the session listens to. They are sent
+	// on every connect via the X-Webhook-Ids header so the server can recreate
+	// the session if it has expired server-side.
+	WebhookIDs []string
+
+	// SessionFiltersJSON is the JSON-encoded session filters, sent on every
+	// connect via the X-Session-Filters header (base64-encoded). Nil when the
+	// session has no filters.
+	SessionFiltersJSON []byte
 }
 
 // EventHandler handles an event.
@@ -82,12 +93,25 @@ type Client struct {
 	done        chan struct{}
 	isConnected bool
 
+	// sessionExpired is set when the server indicates the session no longer
+	// exists (close code 4001, or an "Unknown WebSocket ID." rejection during
+	// the upgrade). The owner of the client should create a new session
+	// instead of reconnecting with the same websocket ID.
+	sessionExpired atomic.Bool
+
 	NotifyExpired chan struct{}
 	notifyClose   chan error
 	send          chan *OutgoingMessage
 	stopReadPump  chan struct{}
 	stopWritePump chan struct{}
 	wg            *sync.WaitGroup
+}
+
+// SessionExpired reports whether the server indicated that the session tied
+// to this client's WebSocketID no longer exists. When true, reconnecting with
+// the same WebSocketID cannot succeed; a new session must be created first.
+func (c *Client) SessionExpired() bool {
+	return c.sessionExpired.Load()
 }
 
 // Connected returns a channel that's closed when the client has finished
@@ -123,6 +147,7 @@ func (c *Client) Run(ctx context.Context) {
 		}).Debug("Failed to connect to Hookdeck. Retrying...")
 
 		if err == ErrUnknownID {
+			c.sessionExpired.Store(true)
 			c.cfg.Log.WithFields(log.Fields{
 				"prefix": "websocket.client.Run",
 			}).Debug("Websocket session is expired.")
@@ -205,14 +230,20 @@ var unknownIDMessage string = "Unknown WebSocket ID."
 // ErrUnknownID can occur when the websocket session is expired or invalid
 var ErrUnknownID error = errors.New(unknownIDMessage)
 
+// closeSessionExpired is the close code the server sends when the session
+// tied to the Websocket-Id header no longer exists (SESSION_EXPIRED) or the
+// session-recreation headers could not be parsed (INVALID_SESSION_DATA).
+const closeSessionExpired = 4001
+
 func basicAuth(username, password string) string {
 	auth := username + ":" + password
 	return base64.StdEncoding.EncodeToString([]byte(auth))
 }
 
-// connect makes a single attempt to connect to the websocket URL. It returns
-// the success of the attempt.
-func (c *Client) connect(ctx context.Context) error {
+// connectHeaders builds the headers sent with the websocket upgrade request.
+// X-Webhook-Ids and X-Session-Filters let the server recreate the session if
+// it has expired server-side (e.g. Redis TTL) while the CLI is still running.
+func (c *Client) connectHeaders() http.Header {
 	header := http.Header{}
 	// Disable compression by requiring "identity"
 	header.Set("Accept-Encoding", "identity")
@@ -221,6 +252,23 @@ func (c *Client) connect(ctx context.Context) error {
 	header.Set("Websocket-Id", c.WebSocketID)
 	header.Set("X-Team-Id", c.TeamID)
 	header.Set("Authorization", "Basic "+basicAuth(c.CLIKey, ""))
+
+	if len(c.cfg.WebhookIDs) > 0 {
+		header.Set("X-Webhook-Ids", strings.Join(c.cfg.WebhookIDs, ","))
+	}
+	// Base64 keeps non-ASCII filter values intact; the server decodes the
+	// header as base64-encoded JSON.
+	if len(c.cfg.SessionFiltersJSON) > 0 {
+		header.Set("X-Session-Filters", base64.StdEncoding.EncodeToString(c.cfg.SessionFiltersJSON))
+	}
+
+	return header
+}
+
+// connect makes a single attempt to connect to the websocket URL. It returns
+// the success of the attempt.
+func (c *Client) connect(ctx context.Context) error {
+	header := c.connectHeaders()
 
 	url := c.URL
 	if c.cfg.NoWSS && strings.HasPrefix(url, "wss") {
@@ -309,6 +357,12 @@ func (c *Client) readPump() {
 					"prefix": "websocket.Client.readPump",
 				}).Debug("stopReadPump")
 			default:
+				if ws.IsCloseError(err, closeSessionExpired) {
+					c.sessionExpired.Store(true)
+					c.cfg.Log.WithFields(log.Fields{
+						"prefix": "websocket.Client.readPump",
+					}).Debug("Server closed the connection because the session expired: ", err)
+				}
 				switch {
 				case !ws.IsCloseError(err):
 					// read errors do not prevent websocket reconnects in the CLI so we should

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -1,0 +1,124 @@
+package websocket
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	ws "github.com/gorilla/websocket"
+)
+
+func TestConnectHeadersIncludeSessionRecreationData(t *testing.T) {
+	filtersJSON := []byte(`{"body":{"event_type":"PAYOUT_NORMAL_FAILED"}}`)
+
+	client := NewClient("wss://example.com", "cses_123", "key_123", "tm_123", &Config{
+		WebhookIDs:         []string{"web_1", "web_2"},
+		SessionFiltersJSON: filtersJSON,
+	})
+
+	header := client.connectHeaders()
+
+	if got := header.Get("Websocket-Id"); got != "cses_123" {
+		t.Errorf("Websocket-Id = %q, want %q", got, "cses_123")
+	}
+
+	if got := header.Get("X-Webhook-Ids"); got != "web_1,web_2" {
+		t.Errorf("X-Webhook-Ids = %q, want %q", got, "web_1,web_2")
+	}
+
+	encoded := header.Get("X-Session-Filters")
+	if encoded == "" {
+		t.Fatal("X-Session-Filters header is missing")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("X-Session-Filters is not valid base64: %v", err)
+	}
+	if string(decoded) != string(filtersJSON) {
+		t.Errorf("X-Session-Filters decodes to %q, want %q", decoded, filtersJSON)
+	}
+}
+
+func TestConnectHeadersOmitEmptySessionRecreationData(t *testing.T) {
+	client := NewClient("wss://example.com", "cses_123", "key_123", "tm_123", &Config{})
+
+	header := client.connectHeaders()
+
+	if got := header.Get("X-Webhook-Ids"); got != "" {
+		t.Errorf("X-Webhook-Ids = %q, want empty", got)
+	}
+	if got := header.Get("X-Session-Filters"); got != "" {
+		t.Errorf("X-Session-Filters = %q, want empty", got)
+	}
+}
+
+// runClientAgainstServer connects a client to a test websocket server whose
+// handler is given the upgraded connection, then waits for the client to
+// report the connection as lost. It returns the client for assertions.
+func runClientAgainstServer(t *testing.T, handler func(conn *ws.Conn)) *Client {
+	t.Helper()
+
+	upgrader := ws.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("failed to upgrade connection: %v", err)
+			return
+		}
+		defer conn.Close()
+		handler(conn)
+	}))
+	defer server.Close()
+
+	url := "ws" + strings.TrimPrefix(server.URL, "http")
+	client := NewClient(url, "cses_123", "key_123", "tm_123", &Config{
+		WebhookIDs: []string{"web_1"},
+	})
+
+	go client.Run(context.Background())
+
+	select {
+	case <-client.NotifyExpired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the client to report the connection as lost")
+	}
+
+	return client
+}
+
+func TestSessionExpiredCloseSetsSessionExpired(t *testing.T) {
+	client := runClientAgainstServer(t, func(conn *ws.Conn) {
+		deadline := time.Now().Add(time.Second)
+		if err := conn.WriteControl(ws.CloseMessage, ws.FormatCloseMessage(closeSessionExpired, "SESSION_EXPIRED"), deadline); err != nil {
+			t.Errorf("failed to send close message: %v", err)
+			return
+		}
+		// Wait for the client to echo the close frame before tearing down.
+		conn.SetReadDeadline(time.Now().Add(time.Second))
+		conn.ReadMessage()
+	})
+
+	if !client.SessionExpired() {
+		t.Error("SessionExpired() = false after a 4001 close, want true")
+	}
+}
+
+func TestNormalCloseDoesNotSetSessionExpired(t *testing.T) {
+	client := runClientAgainstServer(t, func(conn *ws.Conn) {
+		deadline := time.Now().Add(time.Second)
+		if err := conn.WriteControl(ws.CloseMessage, ws.FormatCloseMessage(ws.CloseGoingAway, "SERVER_SHUTDOWN"), deadline); err != nil {
+			t.Errorf("failed to send close message: %v", err)
+			return
+		}
+		conn.SetReadDeadline(time.Now().Add(time.Second))
+		conn.ReadMessage()
+	})
+
+	if client.SessionExpired() {
+		t.Error("SessionExpired() = true after a 1001 close, want false")
+	}
+}


### PR DESCRIPTION
## Context

The platform's websocket proxy (`hookdeck/core` #4477) stores CLI sessions in Redis with a TTL instead of PostgreSQL. When a session key is missing server-side, the proxy expects the CLI to send session-recreation headers on connect (`x-webhook-ids`, `x-session-filters`) — a contract described in `server/workers/websocketProxy.ts` as something "future CLI versions" will implement — and otherwise closes the connection with code `4001 SESSION_EXPIRED`.

No released CLI version sends those headers or handles that close code. The CLI creates its session once per `listen` run and reuses the same session ID on every reconnect, so once the server-side session disappears (Redis TTL expiry, eviction/failover, or a miss in the PG→Redis migration bridge) the CLI is permanently wedged: it flaps between "Connected" and "Connection lost, reconnecting..." with a dead session ID while every event fails with `CLI_UNAVAILABLE`. Related to the connectivity reports investigated in the internal Slack thread from 2026-08-03 (community report of `CLI_UNAVAILABLE` with a running CLI).

## Changes

Two complementary fixes:

1. **Session-recreation headers on every connect** — the websocket client now sends `X-Webhook-Ids` (comma-separated connection IDs) and `X-Session-Filters` (base64-encoded JSON, matching the server's `parseSessionRecreationHeaders`) with the upgrade request. When the server can't find the session, it transparently recreates it under the same session ID instead of rejecting the connection. This is the primary fix: with these headers, the expired-session case self-heals with no visible interruption.

2. **Session-expired recovery in the reconnect loop** — the client records a session-expired signal when the server closes with code `4001` after connecting (`SESSION_EXPIRED` / `INVALID_SESSION_DATA`) or rejects the upgrade with the legacy `Unknown WebSocket ID.` error. On the next reconnect attempt, the proxy creates a fresh session via the API instead of retrying the dead session ID. This is defense-in-depth for cases the headers can't fix (e.g. malformed recreation data).

`pkg/listen/proxy/proxy.go` also picked up a one-line pre-existing `gofmt` alignment fix in the `Config` struct.

## Testing

- New unit tests in `pkg/websocket/client_test.go`:
  - headers include `X-Webhook-Ids` / `X-Session-Filters` (and base64 round-trips) when configured, and omit them otherwise;
  - a `4001` close from a real (httptest) websocket server sets `SessionExpired()`;
  - a normal `1001` close does not.
- `go build ./...`, `go vet`, and `go test ./...` pass locally, except the pre-existing `pkg/listen/healthcheck` `TestCheckServerHealth_DefaultPorts/HTTPS_default_port` failure, which also fails on a clean checkout in this environment (cannot bind port 443) and is unrelated.
- Not yet verified end-to-end against a server running the new websocket proxy — hence the draft. Suggested verification: start `hookdeck listen`, delete the `cses_*` hash from Redis, and confirm the CLI recovers (headers path) and that a forced `4001` close triggers session recreation (recovery path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MH9LQENoLJSawdD7X4yy2h

---
_Generated by [Claude Code](https://claude.ai/code/session_01MH9LQENoLJSawdD7X4yy2h)_