### PR TITLE
docs: add KNOWN_ISSUES.md with listen session-expiry entry

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,19 @@
+# Known Issues
+
+## `hookdeck listen` can stop delivering events after an extended disconnect
+
+**Symptom:** `hookdeck listen` appears connected but events stop arriving; the Hookdeck
+dashboard shows delivery attempts failing with `CLI_UNAVAILABLE`.
+
+**Why:** A CLI session can expire server-side (for example after your machine has been asleep
+or offline for a while). Affected CLI versions don't automatically re-establish it.
+
+**Recommended fix:** Update to **v2.3.2 or later** — newer versions recover automatically.
+
+- npm: `npm install -g hookdeck-cli@latest`
+- Homebrew: `brew upgrade hookdeck`
+
+**Workaround (until you update):** Stop (`Ctrl+C`) and restart `hookdeck listen`. This creates
+a fresh session and delivery resumes. Logging out / logging in is not required.
+
+**Tracking:** #323


### PR DESCRIPTION
Adds a `KNOWN_ISSUES.md` documenting the `hookdeck listen` session-expiry issue — events silently fail with `CLI_UNAVAILABLE` after an extended disconnect — with the recommended fix (upgrade to **v2.3.2** or later, which recovers automatically) and the restart workaround for users who can't upgrade yet.

Tracks #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQV9qtvETd62qg2iDRR6kY
