### PR TITLE
ci: run unit tests and builds on push to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,13 @@ on:
   pull_request:
     branches:
       - main
+  # Run on merge to main so the merged result is tested, not just each PR branch
+  # in isolation. A PR based on stale main can merge into a combination that no
+  # PR run exercised; this catches that (compile/unit/build only — acceptance
+  # tests stay PR-gated because they hit live APIs and are slow/flaky).
+  push:
+    branches:
+      - main
   # Allow manually triggering CI on a branch
   workflow_dispatch: {}
 


### PR DESCRIPTION
## Summary

Run the `test` workflow (unit tests + cross-platform builds) on **push to `main`**, not only on pull requests.

## Why

Today all functional CI is `pull_request`-only, so nothing runs on the merged result on `main`. A PR branch based on stale `main` can merge into a combination that git accepts textually but no PR run ever exercised — semantic drift can land untested. Running unit + build on push to `main` catches that class immediately and cheaply.

Acceptance tests are intentionally left PR-gated: they hit live Hookdeck APIs and are slow (~12 min) and occasionally flaky, so running them on every `main` push would be noisy and costly.

## Follow-ups (not in this PR)

- Enable branch protection **"require branches to be up to date before merging"** so a PR's acceptance run is against current `main`.
- Fix the residual acceptance flakiness (the 502 retry re-runs a CLI command, which emits a new `invocation_id` and trips the telemetry-consistency assertion), then add an **acceptance gate on the `release` workflow**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQV9qtvETd62qg2iDRR6kY
