### PR TITLE
ci: gate releases on the acceptance suite via a reusable workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,61 @@
+name: Acceptance Tests
+
+# Reusable workflow: runs the acceptance suite (sliced) + telemetry acceptance
+# tests. Called by test-acceptance.yml on pull requests and by release.yml as a
+# gate before publishing. Callers pass secrets via `secrets: inherit`.
+on:
+  workflow_call:
+
+jobs:
+  acceptance:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - slice: "0"
+            api_key_secret: HOOKDECK_CLI_TESTING_API_KEY
+            tags: "basic connection source mcp listen project_use connection_list connection_upsert connection_error_hints connection_oauth_aws connection_update"
+          - slice: "1"
+            api_key_secret: HOOKDECK_CLI_TESTING_API_KEY_2
+            tags: "request event"
+          - slice: "2"
+            api_key_secret: HOOKDECK_CLI_TESTING_API_KEY_3
+            tags: "attempt metrics issue transformation destination gateway"
+    runs-on: ubuntu-latest
+    env:
+      ACCEPTANCE_SLICE: ${{ matrix.slice }}
+      HOOKDECK_CLI_TESTING_API_KEY: ${{ secrets[matrix.api_key_secret] }}
+      HOOKDECK_CLI_TELEMETRY_DISABLED: "1"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.24.9"
+
+      - name: Run Go Acceptance Tests (slice ${{ matrix.slice }})
+        run: go test -tags="${{ matrix.tags }}" ./test/acceptance/... -v -timeout 12m
+
+  # Telemetry proxy tests require the real telemetry header; matrix jobs set
+  # HOOKDECK_CLI_TELEMETRY_DISABLED=1. This job runs -tags=telemetry with
+  # HOOKDECK_CLI_TELEMETRY_DISABLED=0 so telemetry is on even if the repo sets a global opt-out.
+  acceptance-telemetry:
+    runs-on: ubuntu-latest
+    env:
+      ACCEPTANCE_SLICE: "0"
+      HOOKDECK_CLI_TESTING_API_KEY: ${{ secrets.HOOKDECK_CLI_TESTING_API_KEY }}
+      # Explicitly allow telemetry: repo/org env may set HOOKDECK_CLI_TELEMETRY_DISABLED=1 globally.
+      HOOKDECK_CLI_TELEMETRY_DISABLED: "0"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.24.9"
+
+      - name: Run telemetry acceptance tests
+        run: go test -tags=telemetry ./test/acceptance/... -v -timeout 12m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,15 @@ on:
       - "v*"
 
 jobs:
+  # Gate: the release only proceeds if the acceptance suite passes on the tagged
+  # commit. On a transient failure, use "Re-run failed jobs" — builds and the npm
+  # publish only run once acceptance is green, so no re-tag is needed.
+  acceptance:
+    uses: ./.github/workflows/acceptance.yml
+    secrets: inherit
+
   build-mac:
+    needs: [acceptance]
     runs-on: macos-latest
     steps:
       - name: Code checkout
@@ -26,6 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
   build-linux:
+    needs: [acceptance]
     runs-on: ubuntu-latest
     env:
       # https://goreleaser.com/customization/docker_manifest/
@@ -57,6 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
   build-windows:
+    needs: [acceptance]
     runs-on: windows-latest
     steps:
       - name: Code checkout

--- a/.github/workflows/test-acceptance.yml
+++ b/.github/workflows/test-acceptance.yml
@@ -8,54 +8,5 @@ on:
 
 jobs:
   acceptance:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - slice: "0"
-            api_key_secret: HOOKDECK_CLI_TESTING_API_KEY
-            tags: "basic connection source mcp listen project_use connection_list connection_upsert connection_error_hints connection_oauth_aws connection_update"
-          - slice: "1"
-            api_key_secret: HOOKDECK_CLI_TESTING_API_KEY_2
-            tags: "request event"
-          - slice: "2"
-            api_key_secret: HOOKDECK_CLI_TESTING_API_KEY_3
-            tags: "attempt metrics issue transformation destination gateway"
-    runs-on: ubuntu-latest
-    env:
-      ACCEPTANCE_SLICE: ${{ matrix.slice }}
-      HOOKDECK_CLI_TESTING_API_KEY: ${{ secrets[matrix.api_key_secret] }}
-      HOOKDECK_CLI_TELEMETRY_DISABLED: "1"
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.24.9"
-
-      - name: Run Go Acceptance Tests (slice ${{ matrix.slice }})
-        run: go test -tags="${{ matrix.tags }}" ./test/acceptance/... -v -timeout 12m
-
-  # Telemetry proxy tests require the real telemetry header; matrix jobs set
-  # HOOKDECK_CLI_TELEMETRY_DISABLED=1. This job runs -tags=telemetry with
-  # HOOKDECK_CLI_TELEMETRY_DISABLED=0 so telemetry is on even if the repo sets a global opt-out.
-  acceptance-telemetry:
-    runs-on: ubuntu-latest
-    env:
-      ACCEPTANCE_SLICE: "0"
-      HOOKDECK_CLI_TESTING_API_KEY: ${{ secrets.HOOKDECK_CLI_TESTING_API_KEY }}
-      # Explicitly allow telemetry: repo/org env may set HOOKDECK_CLI_TELEMETRY_DISABLED=1 globally.
-      HOOKDECK_CLI_TELEMETRY_DISABLED: "0"
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.24.9"
-
-      - name: Run telemetry acceptance tests
-        run: go test -tags=telemetry ./test/acceptance/... -v -timeout 12m
+    uses: ./.github/workflows/acceptance.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary

Gate the release on the acceptance suite (#326 task 2, following the flake fix in #327). A release now publishes only if acceptance passes on the tagged commit.

## How

Extracts the acceptance jobs into a reusable workflow (`.github/workflows/acceptance.yml`, `workflow_call`) so they aren't duplicated:

- `test-acceptance.yml` (on PR) now calls it.
- `release.yml` adds an `acceptance` job that calls it, and `build-mac` / `build-linux` / `build-windows` (and therefore `publish-npm`) `needs:` it.

So on a tag push: acceptance runs first → builds + npm publish only run if it's green. On a transient failure, **Re-run failed jobs** re-runs acceptance and proceeds if green — no re-tag needed.

## Validation

This PR's own acceptance run exercises the new reusable workflow **via the PR path**, so a broken reusable conversion would surface here before it ever gates a release. The release path calls the same reusable workflow.

## Notes

- Releases now take ~12 min longer (acceptance runs before builds) — the intended trade-off.
- Acceptance still hits live APIs; #327 removed the `invocation_id`/retry flake, and "Re-run failed jobs" covers residual transient failures.
- Branch-protection required checks are unchanged (`unit-test` only), so the reusable-workflow check-name change doesn't affect merge gating.

Closes #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQV9qtvETd62qg2iDRR6kY
