### PR TITLE
docs: correct CLI build and run paths in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This repository contains the Hookdeck CLI, a Go-based command-line tool for mana
 - `pkg/hookdeck/` - API client and models
 - `pkg/config/` - Configuration management
 - `pkg/listen/` - Local webhook forwarding functionality
-- `cmd/hookdeck/` - Main entry point
+- `main.go` - Main entry point (repo root)
 - `REFERENCE.md` - Complete CLI documentation and examples
 
 ### Key Files
@@ -240,7 +240,7 @@ This applies to **`go test`**, **`go mod download`**, **`git`**, **`gh`**, build
 ### Building and Testing
 ```bash
 # Build the CLI
-go build -o hookdeck cmd/hookdeck/main.go
+go build -o hookdeck .
 
 # Run all unit tests (default packages; run from repo root)
 go test ./...
@@ -317,10 +317,10 @@ go vet ./...
 ### Local Development
 ```bash
 # Run CLI directly during development
-go run cmd/hookdeck/main.go <command>
+go run . <command>
 
 # Example: Test login command
-go run cmd/hookdeck/main.go login --help
+go run . login --help
 ```
 
 ### Sandbox and command execution
@@ -430,8 +430,8 @@ Acceptance tests in `test/acceptance/` are partitioned by **feature build tags**
 
 | Command | Purpose |
 |---------|---------|
-| `go run cmd/hookdeck/main.go --help` | View CLI help |
-| `go build -o hookdeck cmd/hookdeck/main.go` | Build CLI binary |
+| `go run . --help` | View CLI help |
+| `go build -o hookdeck .` | Build CLI binary |
 | `go test ./...` | All unit tests (repo root; agents: run with `required_permissions: ["all"]`) |
 | `go test ./pkg/cmd/` | Test command implementations only |
 | `go generate ./...` | Run code generation (if used) |


### PR DESCRIPTION
## Problem

`AGENTS.md` documents the CLI entrypoint as `cmd/hookdeck/main.go`, but there is no `cmd/` directory in this repo — the entrypoint is `main.go` at the repo root. Following the documented build command fails:

```
$ go build -o hookdeck cmd/hookdeck/main.go
stat cmd/hookdeck/main.go: no such file or directory
```

This surfaced when a locally-built `hookdeck` binary went missing and the documented rebuild command didn't work.

## Change

Corrects all six occurrences:

| Line | Before | After |
|---|---|---|
| 12 | `` `cmd/hookdeck/` - Main entry point `` | `` `main.go` - Main entry point (repo root) `` |
| 243 | `go build -o hookdeck cmd/hookdeck/main.go` | `go build -o hookdeck .` |
| 320 | `go run cmd/hookdeck/main.go <command>` | `go run . <command>` |
| 323 | `go run cmd/hookdeck/main.go login --help` | `go run . login --help` |
| 433 | `go run cmd/hookdeck/main.go --help` | `go run . --help` |
| 434 | `go build -o hookdeck cmd/hookdeck/main.go` | `go build -o hookdeck .` |

Uses the package path (`.`) rather than the single file, so the build includes every file in the root package rather than just `main.go`.

## Why it's worth fixing

`AGENTS.md` is the file agents read to learn how to build this repo, so a wrong build command here isn't cosmetic — it's an instruction every future agent follows and fails on.

## Verification

Both replacement forms run against the current tree:

```
$ go build -o hookdeck .     # exit 0, produces working binary
$ ./hookdeck version
hookdeck version main
$ go run . --help            # prints CLI help
```

`grep -rn "cmd/hookdeck" --include="*.md" .` returns no matches after the change.

Docs-only — no code, tests, or build config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013P3MKxbE4rQEYLuz5XR7eA