### PR TITLE
chore(ci): bump Go toolchain to 1.26.6 to clear govulncheck failures

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Run Go Acceptance Tests (slice ${{ matrix.slice }})
         run: go test -tags="${{ matrix.tags }}" ./test/acceptance/... -v -timeout 12m
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Run telemetry acceptance tests
         run: go test -tags=telemetry ./test/acceptance/... -v -timeout 12m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -151,7 +151,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
 
       - name: Build npm binaries with GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/test-npm-build.yml
+++ b/.github/workflows/test-npm-build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
       - name: Run unit tests
         run: go test -short ./pkg/...
 
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
       - name: Run govulncheck
         # Pinned rather than @latest: a new govulncheck release could change
         # behaviour or fail this job with no change to the repo. Bump
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:


### PR DESCRIPTION
## Problem

`govulncheck` is currently failing on **every PR and on `main`**, reporting 5 vulnerabilities in the Go standard library. Every finding is pinned to the CI toolchain, not to any code in this repo:

| Package | Found in | Fixed in | Advisory |
|---|---|---|---|
| `net/url` | `go1.26.5` | `go1.26.6` | [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) |
| `crypto/tls` | `go1.26.5` | `go1.26.6` | [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) |
| `net/http` | `go1.26.5` | `go1.26.6` | [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) |
| `encoding/asn1` | `go1.26.5` | `go1.26.6` | [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) |
| `net/http` (idna) | `go1.26.5` | `go1.26.6` | [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) |

## This is time-based, not a regression

Commit `44fe940` is `main`'s tip. It ran twice with **no code change in between**:

| Commit | Workflow run | Result |
|---|---|---|
| `44fe940` | 2026-08-13 12:15 | ✅ success |
| `44fe940` | 2026-08-14 11:49 | ❌ failure |

Go 1.26.6 shipped these security fixes and the vulnerability database picked them up, so the pinned 1.26.5 became flagged. Any PR opened today fails identically — including one that changes only a Markdown file (see #344).

## Change

Bumps all 12 `go-version` pins from `1.26.5` to `1.26.6`:

- `.github/workflows/test.yml` (5)
- `.github/workflows/release.yml` (4)
- `.github/workflows/acceptance.yml` (2)
- `.github/workflows/test-npm-build.yml` (1)

`.github/workflows/test-homebrew-build.yml` uses `go-version-file: go.mod` and needs no change.

`go.mod` keeps `go 1.25.0`. That is the language-version floor and is independent of the toolchain CI installs; no finding implicates it.

## Verification

- Go 1.26.6 confirmed published and installable via the [Go release index](https://go.dev/dl/?mode=json&include=all)
- All four workflow files re-parsed as valid YAML after the edit
- Existing quoting style preserved per file (`"1.26.6"` in `acceptance.yml`, bare elsewhere)
- Local `govulncheck` could not verify the fix (local toolchain is 1.26.1, older than both versions) — **CI on this PR is the authoritative check**

CI-config only — no application code, tests, or dependencies touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013P3MKxbE4rQEYLuz5XR7eA