### PR TITLE
fix: stop dropping Ctrl-C during interactive login, and let CI see it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,13 @@ jobs:
           go-version: 1.26.6
       - name: Run unit tests
         run: go test -short ./pkg/...
+      # `go test` runs a reduced vet suite (printf, bools, atomic and a few
+      # more) and only over the packages it tests. The full suite is what
+      # catches things like sigchanyzer, which found an unbuffered
+      # signal.Notify channel that had been dropping Ctrl-C on the login
+      # prompt. Run it over ./... so test/ and tools/ are covered too.
+      - name: Run go vet
+        run: go vet ./...
 
   # Keeps the vulnerability scan clean rather than asserting it once. Nothing ran
   # govulncheck before, which is how GO-2026-5932 (x/crypto/openpgp, reached only

--- a/pkg/login/interactive_login.go
+++ b/pkg/login/interactive_login.go
@@ -158,7 +158,11 @@ func protectTerminalState() (chan os.Signal, error) {
 		return nil, err
 	}
 
-	signalChan := make(chan os.Signal)
+	// Buffered by one: signal.Notify never blocks, so it drops signals sent
+	// while nobody is receiving. The goroutine below is started immediately
+	// after, but a Ctrl-C in that window would be discarded and the terminal
+	// left in the raw state the prompt put it in.
+	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt)
 
 	go func() {

--- a/test/acceptance/login_auth_acceptance_test.go
+++ b/test/acceptance/login_auth_acceptance_test.go
@@ -80,12 +80,12 @@ api_key = "hk_test_stale_accept01"
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "go", append([]string{"run", mainGo,
+	cmd := exec.CommandContext(ctx, "go", []string{"run", mainGo,
 		"--api-base", ts.URL,
 		"--hookdeck-config", configPath,
 		"--log-level", "error",
 		"login",
-	})...)
+	}...)
 	cmd.Dir = projectRoot
 	env := appendEnvOverride(os.Environ(), "HOOKDECK_CONFIG_FILE", configPath)
 	env = appendEnvOverride(env, "SSH_CONNECTION", "acceptance-login-mock")
@@ -124,11 +124,11 @@ func TestCIFailsFastWithInvalidAPIKeyAcceptance(t *testing.T) {
 	defer cancel()
 
 	invalidKey := "hk_test_ci_invalid_accept01" // valid shape, not a real key
-	cmd := exec.CommandContext(ctx, "go", append([]string{"run", mainGo,
+	cmd := exec.CommandContext(ctx, "go", []string{"run", mainGo,
 		"--hookdeck-config", configPath,
 		"--log-level", "error",
 		"ci", "--api-key", invalidKey,
-	})...)
+	}...)
 	cmd.Dir = projectRoot
 	env := appendEnvOverride(os.Environ(), "HOOKDECK_CONFIG_FILE", configPath)
 	env = appendEnvOverride(env, "HOOKDECK_CLI_TELEMETRY_DISABLED", "1")


### PR DESCRIPTION
Found while reviewing #378 - unrelated to that change, and already present on `main`.

## The bug

`protectTerminalState` puts the terminal into raw mode for the login prompt and restores it from a goroutine when the user interrupts. The channel was unbuffered:

```go
signalChan := make(chan os.Signal)
signal.Notify(signalChan, os.Interrupt)
```

`signal.Notify` never blocks - it does a non-blocking send and drops the signal if nobody is receiving. The goroutine starts immediately after, but a Ctrl-C landing in that window is discarded, and the terminal stays in the state the prompt put it in: no echo, until the user runs `reset`.

## Note: this is already fixed on `release/v3.0.0`

It landed incidentally inside f2de696 ("fix(mcp): do not sign the user out when a reauth is never completed") and never made it back to `main`, so the 2.x line still has it. The change here is byte-identical to the v3 version, comment included, so the two converge rather than conflict when the branches meet.

## Why CI missed it

`go test` runs a reduced vet suite - printf, bools, atomic and a handful more - and only over the packages under test. `sigchanyzer` is not in that set, and nothing else ran vet:

```yaml
- name: Run unit tests
  run: go test -short ./pkg/...
```

The `unit-test` job now also runs `go vet ./...`, which covers `test/` and `tools/` as well. It is clean at this commit, so the job passes without any other change. Adding it to the existing required job rather than as a new one means no branch-protection changes are needed.

That also surfaced two no-op `append(sliceLiteral)` calls in the acceptance tests, fixed here - adding a vet gate while leaving known vet errors in the tree would be incoherent.

## Deliberately not here

- **Tagged vet.** The step runs untagged, so the 22 acceptance build tags are unchecked. `-tags basic` is clean after this change; the rest are unverified. A tag matrix is a bigger conversation.
- **A gofmt gate.** Roughly 40 files on `main` are already unformatted, so enforcing it needs a repo-wide formatting pass first. Worth doing - it is the other half of why formatting regressions land unnoticed - but not as a rider on this.

## Testing

No test. The race is between `signal.Notify` returning and a goroutine's first receive, which is not reachable from a unit test without a real TTY and precise timing; `term.GetState` fails outright under `go test` because stdin is not a terminal. `go vet` is the check that catches this class, which is why it is now wired into CI - that is the regression guard, rather than a test that would have to fake the very thing being fixed.

Verified: `go build ./...`, `go vet ./...`, `go test -short ./pkg/...`, and `go test -tags basic ./test/acceptance/` all pass.
